### PR TITLE
Validate staging content without publication credentials

### DIFF
--- a/.github/workflows/content.yml
+++ b/.github/workflows/content.yml
@@ -4,9 +4,11 @@ on:
   push:
     paths:
       - 'docs/src/content/**'
+      - '.github/workflows/content.yml'
   pull_request:
     paths:
       - 'docs/src/content/**'
+      - '.github/workflows/content.yml'
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/content.yml
+++ b/.github/workflows/content.yml
@@ -59,9 +59,9 @@ jobs:
           CHANNEL=preview
           if test "${GITHUB_REF_NAME}" = main; then CHANNEL=production; fi
           if test "${GITHUB_REF_NAME}" = staging; then CHANNEL=staging; fi
-          VALIDATE=()
-          if test "${{ github.event_name }}" = pull_request; then VALIDATE+=(--validate-only); fi
-          if test "${{ github.event_name }}" != pull_request; then
+          VALIDATE=(--validate-only)
+          if test "${GITHUB_REF_NAME}" = main && test "${{ github.event_name }}" != pull_request; then
+            VALIDATE=()
             node ./.treeseed/content-publisher/dist/scripts/content/publish-content.js --acceptance --team-id "${TREESEED_TEAM_ID}" > r2-acceptance-receipt.json
           fi
           node ./.treeseed/content-publisher/dist/scripts/content/publish-content.js \


### PR DESCRIPTION
## Outcome

Make the shared content workflow usable on staging without external publication credentials while preserving production R2 publication on main.

## Work authority

- Work item / Issue: Platform SDK-first cutover Gate 0; tracked by https://github.com/treeseed-ai/platform/pull/10
- Proposal / decision: Approved SDK-first standards, GitHub, and cluster cutover plan
- Assignment / checkpoint: Cross-repository staging content-validation correction
- Actor: Codex task `/root`
- Human authority: @adrianwebb
- Agent / capacity provider: Codex Desktop / local Codex capacity provider
- Exact base ref: `staging` at `a444f1cca0cdd61e7854e219d1db243d08531129`
- Exact head ref: `codex/staging-content-validation` at `5893f925135628517a115bb8749caafe43cedd1e`

Contributor mode (select one):

- [ ] Human-authored
- [ ] Agent-assisted under human authority
- [x] Agent-authored under human authority

## Plan

1. Default content execution to deterministic validation-only mode.
2. Permit external acceptance and R2 publication only for non-PR execution on `main`.
3. Prove the PR path needs no R2 credentials, then merge and prove the staging push path is also credential-free.

Current status: exact-head push/PR checks and independent review passed; ready for staging integration.

## Changes and commits

- Initialize `VALIDATE` with `--validate-only`.
- Clear validation-only mode and run R2 acceptance only on `main` outside pull requests.
- Preserve exact source-commit checks, channel labeling, receipts, and production fail-closed behavior.
- Include the workflow path in its own trigger filter so pull-request and staging behavior are exercised when this contract changes.

The exact two-commit branch head is `5893f925135628517a115bb8749caafe43cedd1e`; both commits modify only the content workflow.

## Verification

- `git diff --check` passed.
- Content runs `32208296459` and `32208299440` passed without R2 credentials.
- Package Verify runs `32208296483` and `32208299404` passed.
- The PR receipt is bound to the exact source head, records zero uploads, and has SHA-256 `7b2a924c03ee1f51377c1c454aaeccf5cfb17699bce5ae650032fe2cc6838db0`.
- Independent review found no correction-specific source or security issue.

## Risk and rollback

Risk is accidentally suppressing production publication. The condition explicitly retains R2 acceptance/publication for non-PR `main` execution. Roll back by reverting these one-file commits; never provision production publication secrets merely to make staging validation pass.

## Completion summary

The shared workflow contract is explicit and verified at the exact head: pull requests and staging validate locally; only main can publish externally. The next lifecycle step is staging merge, exact ref read-back, and a credential-free staging Content receipt.

## Submission checklist

- [x] The change is bounded to the stated work item and target repository.
- [x] Exact base and head refs are recorded and the branch is ready for review.
- [x] Verification and compatibility evidence are recorded above.
- [x] No plaintext secrets, credentials, machine state, or unrelated residue are included.
- [x] Plan, status, commits, and completion summary form a complete durable record.
- [x] Rollback or recovery steps are documented and executable.
