### PR TITLE
Preserve provider offers during credential rotation

### DIFF
--- a/src/provider/coordination/coordinator.ts
+++ b/src/provider/coordination/coordinator.ts
@@ -318,7 +318,10 @@ export class CapacityProviderCoordinator {
 		const connected = await this.reconcileConnection(connection);
 		if (!connected.runtime) throw new Error(`Provider connection ${connectionId} is not connected and cannot authorize credential rotation.`);
 		const rotationIdempotencyKey = state.credentialRotationIdempotencyKey ?? `credential-rotation:${connectionId}:${randomUUID()}`;
-		state = nextState(connectionId, state.marketUrl, state, { credentialRotationIdempotencyKey: rotationIdempotencyKey });
+		state = nextState(connectionId, state.marketUrl, state, {
+			offer: connection.offer,
+			credentialRotationIdempotencyKey: rotationIdempotencyKey,
+		});
 		await writeProviderConnectionState(this.dataDir, state);
 		const authorization = await this.client(connected.runtime.marketUrl).authorizeCredentialRotation(connected.runtime.accessToken.accessToken, rotationIdempotencyKey);
 		const exchangeIdempotencyKey = state.credentialExchangeIdempotencyKey ?? `credential:${registrationRequestId}:generation:${authorization.generation}`;

--- a/tests/integration/provider/teams/multi-team-coordinator.test.ts
+++ b/tests/integration/provider/teams/multi-team-coordinator.test.ts
@@ -87,7 +87,8 @@ describe('multi-team capacity provider coordinator', () => {
 				}
 				return json({ error: 'unexpected request' }, 500);
 			};
-			const coordinator = new CapacityProviderCoordinator(await loadProviderManifest(manifestPath), dataDirectory, { env: { TEAM_A_REGISTRATION_KEY: 'tsreg_a_secret', TEAM_B_REGISTRATION_KEY: 'tsreg_b_secret' }, fetch: fetchMock });
+			const loaded = await loadProviderManifest(manifestPath);
+			const coordinator = new CapacityProviderCoordinator(loaded, dataDirectory, { env: { TEAM_A_REGISTRATION_KEY: 'tsreg_a_secret', TEAM_B_REGISTRATION_KEY: 'tsreg_b_secret' }, fetch: fetchMock });
 			const pending = await Promise.all([
 				coordinator.beginJoin({ id: 'team-a', marketUrl: 'https://team-a.example.test', registrationKeyRef: 'env://TEAM_A_REGISTRATION_KEY', offer: { sharePercent: 50, maxConcurrentRunners: 1, capabilities: ['engineering'] } }),
 				coordinator.beginJoin({ id: 'team-b', marketUrl: 'https://team-b.example.test', registrationKeyRef: 'env://TEAM_B_REGISTRATION_KEY', offer: { sharePercent: 50, maxConcurrentRunners: 1, capabilities: ['research'] } }),
@@ -102,9 +103,14 @@ describe('multi-team capacity provider coordinator', () => {
 			expect(durable.manifest.connections).toHaveLength(2);
 			expect(JSON.stringify(durable.manifest)).not.toContain('registrationKeyRef');
 			expect(durable.manifest.connections.map((entry) => entry.membershipCredentialRef)).toEqual(['data://secrets/team-a.credential', 'data://secrets/team-b.credential']);
+			const teamA = loaded.manifest.connections.find((entry) => entry.id === 'team-a');
+			if (!teamA) throw new Error('Expected the approved team-a connection.');
+			teamA.offer = { ...teamA.offer, capabilities: [...teamA.offer.capabilities, 'agent-execution'] };
 			const rotated = await coordinator.rotateConnectionCredential('team-a');
 			expect(rotated.runtime?.credentialId).toBe('credential-team-a-2');
-			expect((await loadProviderManifest(manifestPath)).manifest.connections.find((entry) => entry.id === 'team-b')?.membershipCredentialId).toBe('credential-team-b-1');
+			const rotatedManifest = await loadProviderManifest(manifestPath);
+			expect(rotatedManifest.manifest.connections.find((entry) => entry.id === 'team-a')?.offer.capabilities).toContain('agent-execution');
+			expect(rotatedManifest.manifest.connections.find((entry) => entry.id === 'team-b')?.membershipCredentialId).toBe('credential-team-b-1');
 			const reloaded = await new CapacityProviderCoordinator(await loadProviderManifest(manifestPath), dataDirectory, { fetch: fetchMock }).reconcileAll();
 			expect(reloaded.map((entry) => entry.status)).toEqual(['connected', 'connected']);
 			expect(calls.filter((entry) => entry.url.endsWith('/v1/provider/access-tokens'))).toHaveLength(3);


### PR DESCRIPTION
## Outcome

Rotating a capacity-provider membership credential preserves the connection's current approved offer and capabilities. A rotation can no longer restore stale join-time capabilities and silently remove `agent-execution`.

## Work authority

- Work item / Issue: Platform ledger `REPO-LIFECYCLE-001`; H-006 credential rotation finding
- Proposal / decision: proposal `2aacee09-6868-45ee-9916-b49e07820f78`; accepted decision `e83c29a4-8541-4649-9526-285ec7e8ae01`
- Assignment / checkpoint: H-006 human-approved bootstrap checkpoint; controlled post-merge rotation replay remains the live acceptance checkpoint for exact commit `585ef96af8d9eb271437ac6b21a7f01bda3ed7af`
- Actor: Codex primary implementation agent
- Human authority: `adrianwebb`
- Agent / capacity provider: local provider `provider_XqCG5P_XN7crGeiWYpU4XXfog2bonlZs`; H-006 generation-2 rotation
- Exact base ref: `staging` at `4a35bcc7c99482a682041b890e48426d7f939ca6`
- Exact head ref: `codex/preserve-offer-on-credential-rotation` at `585ef96af8d9eb271437ac6b21a7f01bda3ed7af`

Contributor mode (select one):

- [ ] Human-authored
- [x] Agent-assisted under human authority
- [ ] Agent-authored under human authority

## Plan

1. Refresh durable rotation state with the current manifest connection offer before authorization/exchange.
2. Reproduce a post-join capability change in the coordinator integration test.
3. Prove rotation retains that capability while rotating only the selected team credential.
4. Run package tests/build, exact-head hosted checks, independent review, staging read-back, and controlled live replay.

Status: source implementation and local/hosted verification complete; independent review, staging integration, and live replay remain.

## Changes and commits

- `585ef96af8d9eb271437ac6b21a7f01bda3ed7af` — preserves current connection offer during credential rotation and adds the regression.

## Verification

- `npm exec -- vitest run --config ./vitest.config.ts tests/integration/provider/teams/multi-team-coordinator.test.ts` — 1 file, 6 tests passed.
- `npm run build:dist` — passed.
- `git diff --check` — passed.
- Hosted push Verify run `32404737504` — passed at the exact head.
- Hosted PR Verify run `32404778285` — passed.
- Live pre-fix evidence: H-006 generation-2 rotation succeeded but rematerialized the stale offer and temporarily removed `agent-execution`; inspected offer reapply restored it.

## Risk and rollback

The patch changes only which already-approved offer is persisted during rotation; credential authorization, proof, exchange, file custody, token invalidation, and selected-connection scope remain unchanged. Roll back by reverting `585ef96af8d9eb271437ac6b21a7f01bda3ed7af`. If rollback occurs after a credential rotation, retain the active credential and reapply the inspected current offer before restarting availability.

## Completion summary

H-006 exposed that credential state was current while offer state was stale. This PR refreshes only the offer field from the live manifest before the rotation state machine persists and rematerializes the connection. Local and both hosted package gates pass. Independent review, staging read-back, and a controlled rotation replay remain before final acceptance.

## Submission checklist

- [x] The change is bounded to the stated work item and target repository.
- [x] Exact base and head refs are recorded and the branch is ready for review.
- [x] Verification and compatibility evidence are recorded above.
- [x] No plaintext secrets, credentials, machine state, or unrelated residue are included.
- [x] Plan, status, commits, and completion summary form a complete durable record.
- [x] Rollback or recovery steps are documented and executable.
