### PR TITLE
feat: adopt API-issued workday assignments

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,24 +1,21 @@
 {
   "name": "@treeseed/agent",
-  "version": "0.12.59-dev.fix-sdk-package-lock-integrity.20260818T133929Z",
+  "version": "0.13.0-rc.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@treeseed/agent",
-      "version": "0.12.59-dev.fix-sdk-package-lock-integrity.20260818T133929Z",
+      "version": "0.13.0-rc.1",
       "license": "Apache-2.0",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.29.0",
         "@openai/codex-sdk": "^0.130.0",
-        "@treeseed/sdk": "github:treeseed-ai/sdk#92a66135fbda5575bee058b0ab25339c6c7d6398",
+        "@treeseed/sdk": "0.13.0-rc.5",
         "esbuild": "0.28.0",
         "hono": "^4.8.2",
         "typescript": "^5.9.3",
         "yaml": "^2.8.1"
-      },
-      "bin": {
-        "treeseed-agents": "dist/scripts/agents/agents.js"
       },
       "devDependencies": {
         "@types/node": "^24.6.0",
@@ -3702,9 +3699,9 @@
       "license": "MIT"
     },
     "node_modules/@treeseed/sdk": {
-      "version": "0.12.63-dev.fix-sdk-package-lock-integrity.20260818T124913Z",
-      "resolved": "git+ssh://git@github.com/treeseed-ai/sdk.git#92a66135fbda5575bee058b0ab25339c6c7d6398",
-      "integrity": "sha512-6w9qNqZCmHdgme7C3Ab14xUz5UnAz0HPq5+u1t3fE9Wb3OStn4TQbS6kGJ/l9wwPdoixjD0V2VOcjmjXIzsiuA==",
+      "version": "0.13.0-rc.5",
+      "resolved": "https://registry.npmjs.org/@treeseed/sdk/-/sdk-0.13.0-rc.5.tgz",
+      "integrity": "sha512-X9BhPBdu3LwUahtSGFfjgVYurBVSREDyLz4n5DrM/L4xK4lmCCoXpA2C05MJUdUQt7u3NpJGnuF8egSqTBT9uw==",
       "license": "Apache-2.0",
       "dependencies": {
         "@github/copilot": "1.0.39",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@treeseed/agent",
-  "version": "0.12.59-dev.fix-sdk-package-lock-integrity.20260818T133929Z",
+  "version": "0.13.0-rc.1",
   "description": "Treeseed agent service runtime package.",
   "license": "Apache-2.0",
   "repository": {
@@ -111,7 +111,7 @@
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.29.0",
     "@openai/codex-sdk": "^0.130.0",
-    "@treeseed/sdk": "github:treeseed-ai/sdk#92a66135fbda5575bee058b0ab25339c6c7d6398",
+    "@treeseed/sdk": "0.13.0-rc.5",
     "esbuild": "0.28.0",
     "hono": "^4.8.2",
     "typescript": "^5.9.3",
@@ -121,8 +121,5 @@
     "@types/node": "^24.6.0",
     "tsx": "^4.21.0",
     "vitest": "^4.1.2"
-  },
-  "bin": {
-    "treeseed-agents": "dist/scripts/agents/agents.js"
   }
 }

--- a/src/provider/capacity/assignments/assignment-result-reporter.ts
+++ b/src/provider/capacity/assignments/assignment-result-reporter.ts
@@ -7,6 +7,7 @@ import { settlementUsageActual, usageDimension } from '../accounting/usage-repor
 import { positiveNumberValue, record, stringValue } from '../../configuration/value-utils.ts';
 import { reportProviderRuntimeEvent } from '../../reporting/runtime-event-reporter.ts';
 import { buildAssignmentPerformanceSummary } from './performance-summary.ts';
+import { workdayAssignmentAuthorityProjection } from './workday-assignment-authority.ts';
 
 function retryableCompletionError(error: unknown) {
 	const status = Number(record(error).status ?? 0);
@@ -124,6 +125,7 @@ export async function reportProviderAssignmentResult(input: {
 		const observed=record(await client.assignment(assignmentId)); const latest=record(observed.payload);
 		if(stringValue(latest.id)===assignmentId){ typedAssignment={ ...typedAssignment,...latest } as typeof typedAssignment; capacityEnvelope=record(latest.capacityEnvelope); }
 	}
+	const workdayAuthority = workdayAssignmentAuthorityProjection(typedAssignment as unknown as Record<string, unknown>);
 	const numberValue = positiveNumberValue;
 		const modeMetadata = record(modeResult.metadata);
 		const outputMetadata = record(record(modeResult.outputs).metadata);
@@ -193,7 +195,7 @@ export async function reportProviderAssignmentResult(input: {
 					taskSignature: `${typedAssignment.projectAgentClassId}:${modeResult.mode}`,
 					executionProviderId: typedAssignment.executionProviderId ?? null,
 				},
-				metadata: { runnerId: runnerId, mode: modeResult.mode, agentSlug, activityType: stringValue(record(typedAssignment.metadata).activityType), completion: Object.keys(completion).length ? completion : { disposition: 'completed' }, capacityBudget: record(capacityEnvelope.budget), phaseDurations:{preparationSeconds,executionSeconds,closeoutSeconds,custodySeconds:elapsedSeconds}, source: '@treeseed/agent/provider-runner' },
+				metadata: { runnerId: runnerId, mode: modeResult.mode, agentSlug, activityType: stringValue(record(typedAssignment.metadata).activityType), completion: Object.keys(completion).length ? completion : { disposition: 'completed' }, capacityBudget: record(capacityEnvelope.budget), phaseDurations:{preparationSeconds,executionSeconds,closeoutSeconds,custodySeconds:elapsedSeconds}, workdayAuthority, source: '@treeseed/agent/provider-runner' },
 			}, `assignment:${assignmentId}:terminal-settlement`);
 			await reportProviderRuntimeEvent({ client, assignmentId, event: {
 				id: `assignment-performance:${assignmentId.toLowerCase()}`, eventType: 'provider.assignment.performance.finalized', status: 'completed', component: 'provider-runner',
@@ -213,6 +215,7 @@ export async function reportProviderAssignmentResult(input: {
 							...(modeResult.metadata ?? {}),
 							...record(record(modeResult.outputs).metadata),
 							workspaceCleanup,
+							workdayAuthority,
 						},
 					traceRefs: modeResult.traceRefs ?? {},
 					artifactManifest: modeResult.artifactManifest ?? null,
@@ -239,7 +242,7 @@ export async function reportProviderAssignmentResult(input: {
 					taskSignature: `${typedAssignment.projectAgentClassId}:${modeResult.mode}`,
 					executionProviderId: typedAssignment.executionProviderId ?? null,
 				},
-				metadata: { runnerId, mode: modeResult.mode, agentSlug, activityType: stringValue(record(typedAssignment.metadata).activityType), completion: { disposition: 'suspended' }, capacityBudget: record(capacityEnvelope.budget), phaseDurations:{preparationSeconds,executionSeconds,closeoutSeconds,custodySeconds:elapsedSeconds}, source: '@treeseed/agent/provider-runner' },
+				metadata: { runnerId, mode: modeResult.mode, agentSlug, activityType: stringValue(record(typedAssignment.metadata).activityType), completion: { disposition: 'suspended' }, capacityBudget: record(capacityEnvelope.budget), phaseDurations:{preparationSeconds,executionSeconds,closeoutSeconds,custodySeconds:elapsedSeconds}, workdayAuthority, source: '@treeseed/agent/provider-runner' },
 			}, `assignment:${assignmentId}:terminal-settlement`);
 			return client.returnAssignment(assignmentId, {
 				leaseToken: leaseToken,
@@ -287,6 +290,7 @@ export async function reportProviderAssignmentResult(input: {
 					metadata: {
 						...record(record(modeResult.outputs).metadata),
 						...(modeResult.metadata ?? {}),
+						workdayAuthority,
 					},
 			},
 			fallbackOutput: fallbackOutput ?? undefined,

--- a/src/provider/capacity/assignments/kernel-assignment.ts
+++ b/src/provider/capacity/assignments/kernel-assignment.ts
@@ -1,5 +1,6 @@
 import { assertProviderAssignment, type ProviderAssignment, type ProviderAssignmentCapabilityHandles } from '@treeseed/sdk/agent-capacity';
 import { record, stringValue } from '../../configuration/value-utils.ts';
+import { isApiIssuedWorkdayAssignment } from './workday-assignment-authority.ts';
 
 export function buildKernelProviderAssignment(input: {
 	assignment: Record<string, unknown>;
@@ -16,6 +17,19 @@ export function buildKernelProviderAssignment(input: {
 	capabilityHandles: ProviderAssignmentCapabilityHandles;
 }): ProviderAssignment {
 	const { assignment, assignmentId, membershipId, stateVersion, decisionInput, decisionPayload, capacityEnvelope, projectId, agentSlug, workspaceMode, treedxProxyHandle, capabilityHandles } = input;
+	if (isApiIssuedWorkdayAssignment(assignment)) {
+		return assertProviderAssignment({
+			...assignment,
+			treedxProxyHandle,
+			capabilityHandles,
+			workspaceContext: {
+				...record(assignment.workspaceContext),
+				workspaceAccessMode: workspaceMode,
+				treedxProxyHandle,
+				capabilityHandles,
+			},
+		});
+	}
 	return assertProviderAssignment({
 		...assignment,
 		id: assignmentId,

--- a/src/provider/capacity/assignments/workday-assignment-authority.ts
+++ b/src/provider/capacity/assignments/workday-assignment-authority.ts
@@ -1,0 +1,92 @@
+import type { ProviderAssignment } from '@treeseed/sdk/agent-capacity';
+import { record, stringValue } from '../../configuration/value-utils.ts';
+
+export interface WorkdayAssignmentAuthorityDiagnostic {
+	code: string;
+	path: string;
+	message: string;
+}
+
+function required(
+	diagnostics: WorkdayAssignmentAuthorityDiagnostic[],
+	value: unknown,
+	path: string,
+	code: string,
+) {
+	const resolved = stringValue(value);
+	if (!resolved) diagnostics.push({ code, path, message: `API-issued workday assignment requires ${path}.` });
+	return resolved;
+}
+
+function conflict(
+	diagnostics: WorkdayAssignmentAuthorityDiagnostic[],
+	left: string | null,
+	right: string | null,
+	path: string,
+) {
+	if (left && right && left !== right) diagnostics.push({
+		code: 'workday_assignment_authority_conflict',
+		path,
+		message: `API-issued workday assignment contains conflicting ${path} identities.`,
+	});
+}
+
+export function validateWorkdayAssignmentAuthority(value: Record<string, unknown>): WorkdayAssignmentAuthorityDiagnostic[] {
+	if (stringValue(value.synthesizedFrom) !== 'workday_demand') return [];
+	const diagnostics: WorkdayAssignmentAuthorityDiagnostic[] = [];
+	const metadata = record(value.metadata);
+	const envelope = record(value.capacityEnvelope);
+	const decisionInput = record(value.decisionInput);
+	const decisionMetadata = record(decisionInput.metadata);
+	const mode = required(diagnostics, value.mode, 'mode', 'workday_assignment_mode_missing');
+	const teamId = required(diagnostics, value.teamId, 'teamId', 'workday_assignment_team_missing');
+	const projectId = required(diagnostics, value.projectId, 'projectId', 'workday_assignment_project_missing');
+	const providerId = required(diagnostics, value.capacityProviderId, 'capacityProviderId', 'workday_assignment_provider_missing');
+	const classId = required(diagnostics, value.projectAgentClassId, 'projectAgentClassId', 'workday_assignment_class_missing');
+	const workdayId = required(diagnostics, value.workDayId, 'workDayId', 'workday_assignment_workday_missing');
+	required(diagnostics, metadata.workdayRunId, 'metadata.workdayRunId', 'workday_assignment_run_missing');
+	const demandId = required(diagnostics, metadata.demandId, 'metadata.demandId', 'workday_assignment_demand_missing');
+	required(diagnostics, value.allocationSetId, 'allocationSetId', 'workday_assignment_allocation_missing');
+	required(diagnostics, value.reservationId, 'reservationId', 'workday_assignment_reservation_missing');
+	required(diagnostics, value.membershipId, 'membershipId', 'workday_assignment_membership_missing');
+	if (!Number.isInteger(Number(value.stateVersion)) || Number(value.stateVersion) < 1) diagnostics.push({
+		code: 'workday_assignment_state_version_invalid',
+		path: 'stateVersion',
+		message: 'API-issued workday assignment requires a positive stateVersion.',
+	});
+	conflict(diagnostics, teamId, stringValue(envelope.teamId), 'teamId');
+	conflict(diagnostics, projectId, stringValue(envelope.projectId), 'projectId');
+	conflict(diagnostics, providerId, stringValue(envelope.capacityProviderId), 'capacityProviderId');
+	conflict(diagnostics, classId, stringValue(envelope.projectAgentClassId), 'projectAgentClassId');
+	conflict(diagnostics, workdayId, stringValue(envelope.workDayId), 'workDayId');
+	conflict(diagnostics, mode, stringValue(envelope.mode), 'mode');
+	conflict(diagnostics, demandId, stringValue(decisionMetadata.demandId), 'demandId');
+	if (mode === 'acting') {
+		required(diagnostics, value.decisionId, 'decisionId', 'workday_acting_decision_missing');
+		required(diagnostics, decisionMetadata.capacityPlanId, 'decisionInput.metadata.capacityPlanId', 'workday_acting_capacity_plan_missing');
+	}
+	return diagnostics;
+}
+
+export function isApiIssuedWorkdayAssignment(value: Record<string, unknown>): value is Record<string, unknown> & ProviderAssignment {
+	return stringValue(value.synthesizedFrom) === 'workday_demand'
+		&& validateWorkdayAssignmentAuthority(value).length === 0;
+}
+
+export function workdayAssignmentAuthorityProjection(value: Record<string, unknown>) {
+	if (stringValue(value.synthesizedFrom) !== 'workday_demand') return null;
+	const metadata = record(value.metadata);
+	const decisionMetadata = record(record(value.decisionInput).metadata);
+	return {
+		workdayRunId: stringValue(metadata.workdayRunId),
+		workdayId: stringValue(value.workDayId),
+		demandId: stringValue(metadata.demandId),
+		allocationSetId: stringValue(value.allocationSetId),
+		projectAgentClassId: stringValue(value.projectAgentClassId),
+		reservationId: stringValue(value.reservationId),
+		capacityProviderId: stringValue(value.capacityProviderId),
+		decisionId: stringValue(value.decisionId),
+		capacityPlanId: stringValue(decisionMetadata.capacityPlanId),
+		stateVersion: Number(value.stateVersion),
+	};
+}

--- a/src/provider/configuration/config.ts
+++ b/src/provider/configuration/config.ts
@@ -4,7 +4,7 @@ import {
 } from '@treeseed/sdk/capacity-provider';
 import type { AgentSdkTreeDxOptions } from '@treeseed/sdk/sdk';
 import { mintTreeDxHs256Token } from '@treeseed/sdk/treedx/auth';
-import { existsSync } from 'node:fs';
+import { existsSync, readFileSync } from 'node:fs';
 import { resolveCodexAuthFile } from '../../agents/adapters/accounts/codex-auth.ts';
 import {
 	resolveJiraExecutionProviderConfig,
@@ -20,6 +20,8 @@ import {
 } from '../../agents/adapters/integrations/execution-discord.ts';
 
 export type ProviderRole = 'manager' | 'runner' | 'doctor' | 'healthcheck' | 'plan' | 'version';
+
+const packageVersion = String(JSON.parse(readFileSync(new URL('../../../package.json', import.meta.url), 'utf8')).version);
 
 export interface JiraProviderRuntimeConfig extends JiraExecutionProviderConfig {}
 export interface GitHubIssuesProviderRuntimeConfig extends GitHubIssuesExecutionProviderConfig {}
@@ -237,5 +239,5 @@ export function resolveProviderConfig(options: {
 }
 
 export function providerRuntimeVersion(env: NodeJS.ProcessEnv = process.env) {
-	return envValue(env, 'TREESEED_PROVIDER_RUNTIME_VERSION') || '0.9.0';
+	return envValue(env, 'TREESEED_PROVIDER_RUNTIME_VERSION') || packageVersion;
 }

--- a/src/provider/coordination/client.ts
+++ b/src/provider/coordination/client.ts
@@ -1,5 +1,5 @@
 import { ProviderProtocolClient } from '@treeseed/sdk/capacity-provider';
-import type { ProviderConnectionRuntimeContext } from '../configuration/config.ts';
+import { providerRuntimeVersion, type ProviderConnectionRuntimeContext } from '../configuration/config.ts';
 
 // Assignment acquisition performs API-owned synthesis before a lease can be
 // returned. Keep the provider transport deadline comfortably beyond the
@@ -13,7 +13,7 @@ export function createProviderMarketClient(config: ProviderConnectionRuntimeCont
 		marketUrl: config.marketUrl,
 		accessToken: config.accessToken,
 		accessTokenProvider: config.accessTokenProvider,
-		userAgent: `@treeseed/agent capacity-provider/${process.env.TREESEED_PROVIDER_RUNTIME_VERSION ?? '0.9.0'}`,
+		userAgent: `@treeseed/agent capacity-provider/${providerRuntimeVersion()}`,
 		requestTimeoutMs: PROVIDER_MARKET_REQUEST_TIMEOUT_MS,
 	});
 }

--- a/src/provider/operations/runner.ts
+++ b/src/provider/operations/runner.ts
@@ -11,6 +11,7 @@ import { recordEarlyModeRun } from '../reporting/mode-run-reporter.ts';
 import { reportProviderAssignmentResult } from '../capacity/assignments/assignment-result-reporter.ts';
 import type { ProviderAssignmentExecutionInput } from './runner-contracts.ts';
 import { prepareAssignmentKernelBridge } from '../execution/kernel-bridge.ts';
+import { validateWorkdayAssignmentAuthority, workdayAssignmentAuthorityProjection } from '../capacity/assignments/workday-assignment-authority.ts';
 
 
 
@@ -60,6 +61,18 @@ export async function refreshAssignmentAccessToken(config: ProviderConnectionRun
 export async function runProviderAssignment(input: ProviderAssignmentExecutionInput) {
 	input = { ...input, config: await refreshAssignmentAccessToken(input.config, input.assignment) };
 	const assignmentId = stringValue(input.assignment.id) ?? '';
+	const workdayAuthorityDiagnostics = validateWorkdayAssignmentAuthority(input.assignment);
+	if (workdayAuthorityDiagnostics.length > 0) {
+		return input.client.failAssignment(assignmentId, {
+			leaseToken: input.leaseToken,
+			runnerId: input.runnerId,
+			code: 'workday_assignment_authority_invalid',
+			message: 'Provider rejected incomplete or conflicting API-issued workday authority before execution.',
+			retryable: false,
+			metadata: { diagnostics: workdayAuthorityDiagnostics },
+		});
+	}
+	const workdayAuthority = workdayAssignmentAuthorityProjection(input.assignment);
 	const membershipId = stringValue(input.assignment.membershipId);
 	const stateVersion = Number(input.assignment.stateVersion);
 	const decisionInput = record(input.assignment.decisionInput);
@@ -115,6 +128,7 @@ export async function runProviderAssignment(input: ProviderAssignmentExecutionIn
 			projectId,
 			agentSlug,
 			runnerId: input.runnerId,
+			workdayAuthority,
 		},
 	});
 	const prepared = await prepareAssignmentKernelBridge({

--- a/tests/contract/agents/agent-test-catalog.test.ts
+++ b/tests/contract/agents/agent-test-catalog.test.ts
@@ -116,5 +116,5 @@ describe('agent test catalog', () => {
 });
 
 function resolveRepoRoot() {
-	return new URL('../../../../..', import.meta.url).pathname;
+	return new URL('../../..', import.meta.url).pathname;
 }

--- a/tests/contract/package/package-shape.test.ts
+++ b/tests/contract/package/package-shape.test.ts
@@ -29,31 +29,20 @@ function sourcePathForDistSpecifier(specifier: string) {
 	return resolve(packageRoot, 'src', withoutPrefix);
 }
 
-function sourcePathForBinSpecifier(specifier: string) {
-	const withoutPrefix = specifier.replace(/^dist\/scripts\//u, '').replace(/\.js$/u, '.ts');
-	return resolve(packageRoot, 'scripts', withoutPrefix);
-}
-
 describe('agent package shape', () => {
 	it('keeps public exports and bins mapped to owned source files', () => {
 		const packageJson = readJson<{
-			bin: Record<string, string>;
+			bin?: Record<string, string>;
 			exports: Record<string, { default: string; types: string }>;
 			scripts: Record<string, string>;
 		}>(resolve(packageRoot, 'package.json'));
 
-		expect(packageJson.bin).toEqual({
-			'treeseed-agents': 'dist/scripts/agents/agents.js',
-		});
+		expect(packageJson.bin).toBeUndefined();
 
 		for (const [exportName, exportValue] of Object.entries(packageJson.exports)) {
 			expect(exportValue.default, `${exportName} default export`).toMatch(/^\.\/dist\/.+\.js$/u);
 			expect(exportValue.types, `${exportName} type export`).toMatch(/^\.\/dist\/.+\.d\.ts$/u);
 			expect(existsSync(sourcePathForDistSpecifier(exportValue.default)), `${exportName} source file`).toBe(true);
-		}
-
-		for (const [binName, binPath] of Object.entries(packageJson.bin)) {
-			expect(existsSync(sourcePathForBinSpecifier(binPath)), `${binName} source file`).toBe(true);
 		}
 
 			expect(packageJson.scripts.verify).toBe('TMPDIR=/tmp node --import tsx ./scripts/support/verify-driver.ts');

--- a/tests/fixtures/runtime-site/src/manifest.yaml
+++ b/tests/fixtures/runtime-site/src/manifest.yaml
@@ -1,0 +1,7 @@
+id: treeseed-agent-runtime-test
+siteConfigPath: ./src/config.yaml
+content:
+  pages: ./src/content/pages
+  agents: ./src/content/agents
+features:
+  agents: true

--- a/tests/fixtures/runtime-site/treeseed.site.yaml
+++ b/tests/fixtures/runtime-site/treeseed.site.yaml
@@ -1,0 +1,29 @@
+name: TreeSeed Agent Runtime Test
+slug: treeseed-agent-runtime-test
+siteUrl: https://agent-runtime.test
+contactEmail: test@agent-runtime.invalid
+hosting:
+  kind: hosted_project
+  registration: optional
+  marketBaseUrl: https://api.treeseed.invalid
+  teamId: treeseed-agent-runtime-test
+  projectId: treeseed-agent-runtime-test
+cloudflare:
+  accountId: fixture-account
+  workerName: treeseed-agent-runtime-test
+  pages:
+    projectName: treeseed-agent-runtime-test
+    previewProjectName: treeseed-agent-runtime-test-staging
+    productionBranch: main
+    stagingBranch: staging
+    buildOutputDir: dist
+providers:
+  agents:
+    execution: codex
+    mutation: local_branch
+    repository: git
+    verification: local
+    notification: sdk_message
+    research: project_graph
+  deploy: cloudflare
+  site: default

--- a/tests/integration/provider/capacity/assignments/assignment-runtime.fails-closed-when-a-leased-assignment-lacks-canonical-project-context.test.ts
+++ b/tests/integration/provider/capacity/assignments/assignment-runtime.fails-closed-when-a-leased-assignment-lacks-canonical-project-context.test.ts
@@ -81,7 +81,7 @@ function leasedAssignment(repoRoot: string) {
 		providerSessionId: 'session-a',
 		executionProviderId: null,
 		laneId: null,
-		allocationSetId: null,
+		allocationSetId: 'allocation-set-a',
 		projectAgentClassId: 'researcher',
 		reservationId: 'reservation-a',
 		workDayId: 'workday-a',
@@ -95,8 +95,8 @@ function leasedAssignment(repoRoot: string) {
 		leaseToken: 'lease-a',
 		leaseRenewedAt: null,
 		runnerId: 'runner-a',
-		decisionInput: { teamId: 'team-a', projectId: 'project-a', projectAgentClassId: 'researcher', agentId: 'researcher', handlerId: 'execution-content', mode: 'planning', input: {} },
-		capacityEnvelope: { teamId: 'team-a', projectId: 'project-a', projectAgentClassId: 'researcher', capacityProviderId: 'provider-a', mode: 'planning' as const, reservedSeconds: 3 },
+		decisionInput: { teamId: 'team-a', projectId: 'project-a', projectAgentClassId: 'researcher', agentId: 'researcher', handlerId: 'execution-content', mode: 'planning', input: {}, metadata: { demandId: 'demand-a' } },
+		capacityEnvelope: { teamId: 'team-a', projectId: 'project-a', projectAgentClassId: 'researcher', capacityProviderId: 'provider-a', workDayId: 'workday-a', mode: 'planning' as const, reservedSeconds: 3, metadata: { demandId: 'demand-a' } },
 		workspaceContext: { project: projectContext(repoRoot) },
 		allowedOutputs: {},
 		explanation: {},
@@ -116,7 +116,7 @@ function leasedAssignment(repoRoot: string) {
 		fallbackOutputId: null,
 		treedxProxyHandle: null,
 		capabilityHandles: null,
-		metadata: {},
+		metadata: { demandId: 'demand-a', workdayRunId: 'workday-run-a' },
 		createdAt: new Date().toISOString(),
 		updatedAt: new Date().toISOString(),
 	};
@@ -344,7 +344,7 @@ it('bounds assignment-scoped TreeDX response bodies before AgentKernel execution
 		}));
 		const assignment = {
 			...leasedAssignment(repoRoot),
-			metadata: { assignmentSource: 'capacity_workday_demand', contentRoot: 'src/content' },
+			metadata: { ...leasedAssignment(repoRoot).metadata, assignmentSource: 'capacity_workday_demand', contentRoot: 'src/content' },
 			treedxProxyHandle: {
 				id: 'handle-a', teamId: 'team-a', projectId: 'project-a', assignmentId: 'assignment-a', repositoryId: 'repo-a', workspaceId: 'workspace-a',
 				allowedOperations: ['files:read'], allowedPaths: ['**'], expiresAt: new Date(Date.now() + 60_000).toISOString(),

--- a/tests/integration/provider/capacity/assignments/assignment-runtime.releases-internal-execution-provider-resources-only-after-a-durable-terminal-response.test.ts
+++ b/tests/integration/provider/capacity/assignments/assignment-runtime.releases-internal-execution-provider-resources-only-after-a-durable-terminal-response.test.ts
@@ -84,7 +84,7 @@ function leasedAssignment(repoRoot: string) {
 		providerSessionId: 'session-a',
 		executionProviderId: null,
 		laneId: null,
-		allocationSetId: null,
+		allocationSetId: 'allocation-set-a',
 		projectAgentClassId: 'researcher',
 		reservationId: 'reservation-a',
 		workDayId: 'workday-a',
@@ -98,8 +98,8 @@ function leasedAssignment(repoRoot: string) {
 		leaseToken: 'lease-a',
 		leaseRenewedAt: null,
 		runnerId: 'runner-a',
-		decisionInput: { teamId: 'team-a', projectId: 'project-a', projectAgentClassId: 'researcher', agentId: 'researcher', handlerId: 'execution-content', mode: 'planning', input: {} },
-		capacityEnvelope: { teamId: 'team-a', projectId: 'project-a', projectAgentClassId: 'researcher', capacityProviderId: 'provider-a', mode: 'planning' as const, reservedCredits: 3 },
+		decisionInput: { teamId: 'team-a', projectId: 'project-a', projectAgentClassId: 'researcher', agentId: 'researcher', handlerId: 'execution-content', mode: 'planning', input: {}, metadata: { demandId: 'demand-a' } },
+		capacityEnvelope: { teamId: 'team-a', projectId: 'project-a', projectAgentClassId: 'researcher', capacityProviderId: 'provider-a', workDayId: 'workday-a', mode: 'planning' as const, reservedCredits: 3, metadata: { demandId: 'demand-a' } },
 		workspaceContext: { project: projectContext(repoRoot) },
 		allowedOutputs: {},
 		explanation: {},
@@ -119,7 +119,7 @@ function leasedAssignment(repoRoot: string) {
 		fallbackOutputId: null,
 		treedxProxyHandle: null,
 		capabilityHandles: null,
-		metadata: {},
+		metadata: { demandId: 'demand-a', workdayRunId: 'workday-run-a' },
 		createdAt: new Date().toISOString(),
 		updatedAt: new Date().toISOString(),
 	};
@@ -307,7 +307,7 @@ it('fails local materialization before kernel execution when the governed exact 
 		expect(materialized.repository.error).toContain(`governed exact ref ${missingRef}`);
 	});
 
-it('fails closed before kernel execution when assignment governance provenance is missing', async () => {
+it('fails closed before kernel execution when API-issued workday authority is incomplete', async () => {
 		const repoRoot = repository();
 		const assignment = leasedAssignment(repoRoot);
 		delete (assignment as Partial<typeof assignment>).membershipId;
@@ -328,6 +328,6 @@ it('fails closed before kernel execution when assignment governance provenance i
 			kernel: { async runAssignment() { throw new Error('kernel must not execute'); } },
 		});
 		expect(result).toMatchObject({ ok: true, payload: { status: 'failed' } });
-		expect(failures).toEqual([expect.objectContaining({ code: 'assignment_governance_provenance_missing', retryable: false })]);
+		expect(failures).toEqual([expect.objectContaining({ code: 'workday_assignment_authority_invalid', retryable: false })]);
 	});
 });

--- a/tests/integration/provider/capacity/assignments/assignment-runtime.returns-a-leased-assignment-after-an-unexpected-preparation-failure.test.ts
+++ b/tests/integration/provider/capacity/assignments/assignment-runtime.returns-a-leased-assignment-after-an-unexpected-preparation-failure.test.ts
@@ -80,7 +80,7 @@ function leasedAssignment(repoRoot: string) {
 		providerSessionId: 'session-a',
 		executionProviderId: null,
 		laneId: null,
-		allocationSetId: null,
+		allocationSetId: 'allocation-set-a',
 		projectAgentClassId: 'researcher',
 		reservationId: 'reservation-a',
 		workDayId: 'workday-a',
@@ -94,8 +94,8 @@ function leasedAssignment(repoRoot: string) {
 		leaseToken: 'lease-a',
 		leaseRenewedAt: null,
 		runnerId: 'runner-a',
-		decisionInput: { teamId: 'team-a', projectId: 'project-a', projectAgentClassId: 'researcher', agentId: 'researcher', handlerId: 'execution-content', mode: 'planning', input: {} },
-		capacityEnvelope: { teamId: 'team-a', projectId: 'project-a', projectAgentClassId: 'researcher', capacityProviderId: 'provider-a', mode: 'planning' as const, reservedSeconds: 3 },
+		decisionInput: { teamId: 'team-a', projectId: 'project-a', projectAgentClassId: 'researcher', agentId: 'researcher', handlerId: 'execution-content', mode: 'planning', input: {}, metadata: { demandId: 'demand-a' } },
+		capacityEnvelope: { teamId: 'team-a', projectId: 'project-a', projectAgentClassId: 'researcher', capacityProviderId: 'provider-a', workDayId: 'workday-a', mode: 'planning' as const, reservedSeconds: 3, metadata: { demandId: 'demand-a' } },
 		workspaceContext: { project: projectContext(repoRoot) },
 		allowedOutputs: {},
 		explanation: {},
@@ -115,7 +115,7 @@ function leasedAssignment(repoRoot: string) {
 		fallbackOutputId: null,
 		treedxProxyHandle: null,
 		capabilityHandles: null,
-		metadata: {},
+		metadata: { demandId: 'demand-a', workdayRunId: 'workday-run-a' },
 		createdAt: new Date().toISOString(),
 		updatedAt: new Date().toISOString(),
 	};
@@ -167,7 +167,7 @@ it('returns a leased assignment after an unexpected preparation failure', async 
 		const calls: Array<{ method: string; body?: Record<string, unknown> }> = [];
 		const assignment = {
 			...leasedAssignment(repoRoot),
-			metadata: { assignmentSource: 'capacity_workday_demand', contentRoot: 'src/content' },
+			metadata: { ...leasedAssignment(repoRoot).metadata, assignmentSource: 'capacity_workday_demand', contentRoot: 'src/content' },
 			decisionInput: { ...leasedAssignment(repoRoot).decisionInput, input: { exactBaseRef: 'immutable-ref-from-treedx' } },
 			workspaceContext: { project: { ...projectContext(repoRoot), repository: { ...projectContext(repoRoot).repository, cloneUrl: 'https://invalid.example/must-not-clone.git' } } },
 			treedxProxyHandle: {

--- a/tests/support/setup-runtime.ts
+++ b/tests/support/setup-runtime.ts
@@ -1,14 +1,8 @@
-import { existsSync } from 'node:fs';
 import { resolve } from 'node:path';
 import { loadManifest } from '@treeseed/sdk/platform/tenant-config';
 import { loadDeployConfig } from '@treeseed/sdk/platform/deploy-config';
 
-const fixtureRoot = [
-	resolve(process.cwd(), '.fixtures/treeseed-fixtures/sites/working-site'),
-	resolve(process.cwd(), '../core/.fixtures/treeseed-fixtures/sites/working-site'),
-	resolve(process.cwd(), '../../.fixtures/treeseed-fixtures/sites/working-site'),
-].find((candidate) => existsSync(resolve(candidate, 'src/manifest.yaml')))
-	?? resolve(process.cwd(), '.fixtures/treeseed-fixtures/sites/working-site');
+const fixtureRoot = resolve(process.cwd(), 'tests/fixtures/runtime-site');
 const tenantConfig = loadManifest(resolve(fixtureRoot, 'src/manifest.yaml'));
 const deployConfig = loadDeployConfig(resolve(fixtureRoot, 'treeseed.site.yaml'));
 

--- a/tests/unit/provider/capacity/assignments/workday-assignment-authority.test.ts
+++ b/tests/unit/provider/capacity/assignments/workday-assignment-authority.test.ts
@@ -1,0 +1,106 @@
+import { describe, expect, it } from 'vitest';
+import { validateWorkdayAssignmentAuthority, workdayAssignmentAuthorityProjection } from '../../../../../src/provider/capacity/assignments/workday-assignment-authority.ts';
+import { runProviderAssignment } from '../../../../../src/provider/operations/runner.ts';
+
+function assignment(overrides: Record<string, unknown> = {}) {
+	return {
+		id: 'assignment-1',
+		membershipId: 'membership-1',
+		stateVersion: 1,
+		teamId: 'team-1',
+		projectId: 'project-1',
+		capacityProviderId: 'provider-1',
+		projectAgentClassId: 'class-1',
+		allocationSetId: 'allocation-1',
+		reservationId: 'reservation-1',
+		workDayId: 'workday-1',
+		mode: 'planning',
+		synthesizedFrom: 'workday_demand',
+		metadata: { workdayRunId: 'run-1', demandId: 'demand-1' },
+		capacityEnvelope: {
+			teamId: 'team-1',
+			projectId: 'project-1',
+			capacityProviderId: 'provider-1',
+			projectAgentClassId: 'class-1',
+			workDayId: 'workday-1',
+			mode: 'planning',
+		},
+		decisionInput: { metadata: { demandId: 'demand-1' } },
+		...overrides,
+	};
+}
+
+describe('API-issued workday assignment authority', () => {
+	it('accepts an exact planning assignment without deriving policy', () => {
+		const value = assignment();
+		expect(validateWorkdayAssignmentAuthority(value)).toEqual([]);
+		expect(workdayAssignmentAuthorityProjection(value)).toEqual({
+			workdayRunId: 'run-1',
+			workdayId: 'workday-1',
+			demandId: 'demand-1',
+			allocationSetId: 'allocation-1',
+			projectAgentClassId: 'class-1',
+			reservationId: 'reservation-1',
+			capacityProviderId: 'provider-1',
+			decisionId: null,
+			capacityPlanId: null,
+			stateVersion: 1,
+		});
+	});
+
+	it('rejects missing authority and cross-record identity conflicts', () => {
+		const diagnostics = validateWorkdayAssignmentAuthority(assignment({
+			allocationSetId: null,
+			reservationId: null,
+			projectAgentClassId: '',
+			capacityEnvelope: { teamId: 'another-team', mode: 'acting' },
+		}));
+		expect(diagnostics.map((entry) => entry.code)).toEqual(expect.arrayContaining([
+			'workday_assignment_allocation_missing',
+			'workday_assignment_reservation_missing',
+			'workday_assignment_class_missing',
+			'workday_assignment_authority_conflict',
+		]));
+	});
+
+	it('requires API-owned decision and capacity-plan evidence for acting', () => {
+		const value = assignment({
+			mode: 'acting',
+			decisionId: null,
+			capacityEnvelope: { ...assignment().capacityEnvelope as Record<string, unknown>, mode: 'acting' },
+		});
+		const diagnostics = validateWorkdayAssignmentAuthority(value);
+		expect(diagnostics.map((entry) => entry.code)).toEqual(expect.arrayContaining([
+			'workday_acting_decision_missing',
+			'workday_acting_capacity_plan_missing',
+		]));
+	});
+
+	it('does not impose the new workday contract on mixed-version legacy assignments', () => {
+		expect(validateWorkdayAssignmentAuthority({ synthesizedFrom: 'approved_decision' })).toEqual([]);
+	});
+
+	it('fails before kernel or workspace preparation when authority is incomplete', async () => {
+		let kernelCalls = 0;
+		const failures: Record<string, unknown>[] = [];
+		const result = await runProviderAssignment({
+			config: { environment: 'local', env: {} } as never,
+			client: {
+				failAssignment: async (_id: string, request: Record<string, unknown>) => {
+					failures.push(request);
+					return { ok: true, payload: { status: 'failed' } };
+				},
+			} as never,
+			assignment: assignment({ reservationId: null }),
+			leaseToken: 'lease-1',
+			runnerId: 'runner-1',
+			leaseSeconds: 60,
+			renewLease: async () => undefined,
+			kernel: { runAssignment: async () => { kernelCalls += 1; return {} as never; } },
+		});
+		expect(result).toEqual({ ok: true, payload: { status: 'failed' } });
+		expect(kernelCalls).toBe(0);
+		expect(failures).toHaveLength(1);
+		expect(failures[0]).toMatchObject({ code: 'workday_assignment_authority_invalid', retryable: false });
+	});
+});

--- a/tests/unit/provider/configuration/runtime-version.test.ts
+++ b/tests/unit/provider/configuration/runtime-version.test.ts
@@ -1,0 +1,12 @@
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { describe, expect, it } from 'vitest';
+import { providerRuntimeVersion } from '../../../../src/provider/configuration/config.ts';
+
+describe('capacity-provider runtime version', () => {
+	it('defaults to the exact package version and permits an explicit image override', () => {
+		const packageVersion = JSON.parse(readFileSync(resolve(process.cwd(), 'package.json'), 'utf8')).version;
+		expect(providerRuntimeVersion({})).toBe(packageVersion);
+		expect(providerRuntimeVersion({ TREESEED_PROVIDER_RUNTIME_VERSION: 'image-build-1' })).toBe('image-build-1');
+	});
+});


### PR DESCRIPTION
## Outcome

Adopts API-issued time-based workday authority in the private Agent capacity-provider runtime, removes the package's public runtime executable, and establishes `@treeseed/agent@0.13.0-rc.1` on the exact semantic SDK RC.

## Work authority

- Work item / Issue: Closes #7
- Proposal / decision: SDK-first cutover Gate 2 prerequisite; tracked in the Platform cutover ledger
- Assignment / checkpoint: Pre-agent implementation only; no live TreeSeed assignment or workday was started
- Actor: OpenAI Codex under Adrian Webb's direction
- Human authority: Adrian Webb
- Agent / capacity provider: Codex development agent; no TreeSeed capacity-provider lease
- Exact base ref: `staging` at `d527ee6791ecee8770eba73721c484916ac7d7dd`
- Exact head ref: `codex/time-based-workday-runtime` at `fc437cf6c728fb123d48177816e9e56d85e7da42`

Contributor mode (select one):

- [ ] Human-authored
- [x] Agent-assisted under human authority
- [ ] Agent-authored under human authority

## Plan

1. Move Agent to exact semantic `@treeseed/sdk@0.13.0-rc.5` and version the breaking runtime adoption as `0.13.0-rc.1`.
2. Validate and preserve API-issued workday, demand, allocation, class, reservation, provider, and decision authority before repository or model execution.
3. Carry that authority through kernel input, telemetry, terminal reporting, and settlement.
4. Remove the public `treeseed-agents` binary while retaining private container manager/runner entrypoints.
5. Make the package test environment self-contained and verify source, packed package, and private container behavior.

Status: implementation and exact-head hosted verification complete; staging integration is ready.

## Changes and commits

- `fc437cf6c728fb123d48177816e9e56d85e7da42` — `feat: adopt API-issued workday assignments`
- Adds a fail-closed workday-assignment authority validator and immutable authority projection.
- Preserves exact API fields for valid workday assignments instead of reconstructing policy inside Agent.
- Adds authority to lifecycle telemetry and terminal settlement/completion/failure output.
- Removes the public Agent executable and replaces the Git SDK dependency with exact semantic RC5.
- Replaces cross-repository test-fixture discovery with a package-owned fixture.
- Derives the private runtime version from the installed package, removing the stale `0.9.0` fallback.

## Verification

- `npm run release:verify` — passed on the exact head: file architecture, declarations/build, 75 test files / 308 tests, smoke, private manager/runner image build and compose smoke, and packed-install provider-runtime smoke.
- Packed runtime `version` read-back returned `0.13.0-rc.1`.
- `npm pack --json --ignore-scripts` — 438 files; tarball SHA-256 `6206ecd60661ae958877f27c0d16c857cca9d4a2e150991854d0fb8cb1323512`; npm integrity `sha512-r6Z8pzkFysbV5MlxY/Qwjq+gjjDkMpSE4DtRVreYDkEALPXN+iAs4hKnXoWgfAgS8UmYYKy0Amk78gk5SuEkVw==`.
- `git diff --check` — passed.
- Generated manager/runner images, pulled smoke image, build cache, and npm execution caches were removed after verification; the three managed local-service images and volumes were untouched.
- Hosted push run `32480330325` and PR run `32480384146` passed at the exact head.

## Risk and rollback

The strict validator intentionally rejects incomplete API-issued `workday_demand` assignments before side effects. Legacy non-workday assignments retain their mixed-version fallback. Roll back by reverting `fc437cf6c728fb123d48177816e9e56d85e7da42`; no database migration or production image promotion is included.

## Completion summary

Agent now consumes rather than derives the accepted API's scheduling authority, reports exact workday lineage throughout the terminal lifecycle, exposes no public low-level runtime CLI, and is independently package-testable. Remaining work is staging merge/read-back, npm RC publication/read-back, and residue cleanup. Live agents remain paused.

## Submission checklist

- [x] The change is bounded to the stated work item and target repository.
- [x] Exact base and head refs are recorded and the branch is ready for review.
- [x] Verification and compatibility evidence are recorded above.
- [x] No plaintext secrets, credentials, machine state, or unrelated residue are included.
- [x] Plan, status, commits, and completion summary form a complete durable record.
- [x] Rollback or recovery steps are documented and executable.
