### PR TITLE
ci: add npm-only Agent prerelease

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -8,25 +8,70 @@ on:
 
 jobs:
   npm:
-    if: startsWith(github.ref, 'refs/tags/') && !contains(github.ref_name, '-')
+    if: startsWith(github.ref, 'refs/tags/')
     runs-on: ubuntu-24.04
     permissions:
       contents: read
       id-token: write
     environment: production
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262
         with:
           submodules: recursive
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020
         with:
           node-version: 24
           registry-url: https://registry.npmjs.org
-      - run: npm ci --ignore-scripts
-      - run: npm run build
-      - run: npm publish --access public --provenance
+      - run: npm run release:setup
+      - run: npm run release:check-tag
+      - run: bash -lc 'npm run verify:local'
+      - name: Pack the exact verified package
+        id: pack
+        shell: bash
+        run: |
+          set -euo pipefail
+          mkdir -p artifacts
+          npm pack --json --ignore-scripts --pack-destination artifacts > artifacts/pack.json
+          filename="$(node -e "const value=require('./artifacts/pack.json'); process.stdout.write(value[0].filename)")"
+          sha256="$(sha256sum "artifacts/${filename}" | awk '{print $1}')"
+          echo "filename=${filename}" >> "$GITHUB_OUTPUT"
+          echo "sha256=${sha256}" >> "$GITHUB_OUTPUT"
+      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
+        with:
+          name: agent-release-${{ github.sha }}
+          path: artifacts/
+          if-no-files-found: error
+      - name: Capture stable tag before publication
+        id: before
+        run: echo "latest=$(npm view @treeseed/agent dist-tags.latest)" >> "$GITHUB_OUTPUT"
+      - run: npm run release:publish -- "artifacts/${{ steps.pack.outputs.filename }}"
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+      - name: Verify immutable npm read-back
+        env:
+          EXPECTED_LATEST: ${{ steps.before.outputs.latest }}
+          EXPECTED_SHA256: ${{ steps.pack.outputs.sha256 }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          deadline=$((SECONDS + 180))
+          while true; do
+            published="$(npm view "@treeseed/agent@${GITHUB_REF_NAME}" version 2>/dev/null || true)"
+            channel="latest"
+            if [[ "${GITHUB_REF_NAME}" == *-rc.* ]]; then channel="rc"; fi
+            tagged="$(npm view "@treeseed/agent" "dist-tags.${channel}" 2>/dev/null || true)"
+            if [[ "${published}" == "${GITHUB_REF_NAME}" && "${tagged}" == "${GITHUB_REF_NAME}" ]]; then break; fi
+            if (( SECONDS >= deadline )); then echo "npm read-back did not converge" >&2; exit 1; fi
+            sleep 3
+          done
+          if [[ "${GITHUB_REF_NAME}" == *-rc.* ]]; then
+            latest="$(npm view @treeseed/agent dist-tags.latest)"
+            [[ "${latest}" == "${EXPECTED_LATEST}" ]] || { echo "prerelease changed npm latest" >&2; exit 1; }
+          fi
+          temp="$(mktemp -d)"
+          npm pack "@treeseed/agent@${GITHUB_REF_NAME}" --ignore-scripts --pack-destination "${temp}" >/dev/null
+          actual="$(sha256sum "${temp}"/*.tgz | awk '{print $1}')"
+          [[ "${actual}" == "${EXPECTED_SHA256}" ]] || { echo "published tarball digest mismatch" >&2; exit 1; }
 
   build:
     if: startsWith(github.ref, 'refs/tags/') && !contains(github.ref_name, '-')
@@ -60,7 +105,7 @@ jobs:
             platform: linux/arm64
             runner: ubuntu-24.04-arm
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262
         with:
           submodules: recursive
       - run: npm ci --ignore-scripts
@@ -71,12 +116,12 @@ jobs:
           version="${GITHUB_REF_NAME#v}"
           echo "base=${version}" >> "$GITHUB_OUTPUT"
           echo "moving=" >> "$GITHUB_OUTPUT"
-      - uses: docker/setup-buildx-action@v3
-      - uses: docker/login-action@v3
+      - uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f
+      - uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9
         with:
           username: ${{ vars.TREESEED_DOCKERHUB_USERNAME }}
           password: ${{ secrets.TREESEED_DOCKERHUB_TOKEN }}
-      - uses: docker/build-push-action@v6
+      - uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8
         with:
           context: .
           target: ${{ matrix.target }}
@@ -100,8 +145,8 @@ jobs:
           - image: treeseed/agent-manager
           - image: treeseed/agent-runner
     steps:
-      - uses: docker/setup-buildx-action@v3
-      - uses: docker/login-action@v3
+      - uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f
+      - uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9
         with:
           username: ${{ vars.TREESEED_DOCKERHUB_USERNAME }}
           password: ${{ secrets.TREESEED_DOCKERHUB_TOKEN }}
@@ -151,8 +196,21 @@ jobs:
     permissions:
       contents: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262
       - name: Create GitHub release
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: gh release create "${GITHUB_REF_NAME}" --generate-notes --verify-tag
+
+  prerelease:
+    needs: npm
+    if: startsWith(github.ref, 'refs/tags/') && contains(github.ref_name, '-rc.')
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262
+      - name: Create GitHub prerelease
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: gh release create "${GITHUB_REF_NAME}" --generate-notes --verify-tag --prerelease

--- a/scripts/packages/assert-release-tag-version.ts
+++ b/scripts/packages/assert-release-tag-version.ts
@@ -1,6 +1,7 @@
 import { readFileSync } from 'node:fs';
 import { resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
+import { parseAgentReleaseVersion } from './release-version.ts';
 
 const packageRoot = resolve(fileURLToPath(new URL('../..', import.meta.url)));
 const packageJson = JSON.parse(readFileSync(resolve(packageRoot, 'package.json'), 'utf8'));
@@ -12,13 +13,10 @@ if (!tagName) {
 	process.exit(1);
 }
 
-if (!/^\d+\.\d+\.\d+$/.test(tagName)) {
-	console.error(`Release tag "${tagName}" must be a plain semver tag like "${packageVersion}".`);
-	process.exit(1);
-}
-
-if (tagName !== packageVersion) {
-	console.error(`Release tag "${tagName}" does not match @treeseed/agent version "${packageVersion}".`);
+try {
+	parseAgentReleaseVersion(tagName, packageVersion);
+} catch (error) {
+	console.error(error instanceof Error ? error.message : String(error));
 	process.exit(1);
 }
 

--- a/scripts/packages/publish-package.ts
+++ b/scripts/packages/publish-package.ts
@@ -1,17 +1,26 @@
 import { spawnSync } from 'node:child_process';
 import { resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
+import { readFileSync } from 'node:fs';
+import { parseAgentReleaseVersion } from './release-version.ts';
 
 const packageRoot = resolve(fileURLToPath(new URL('../..', import.meta.url)));
 const extraArgs = process.argv.slice(2);
 const tagName = process.env.GITHUB_REF_NAME;
+const packageVersion = String(JSON.parse(readFileSync(resolve(packageRoot, 'package.json'), 'utf8')).version);
 
-if (tagName && !/^\d+\.\d+\.\d+$/.test(tagName)) {
-	console.error(`Refusing to publish @treeseed/agent from non-stable tag "${tagName}".`);
-	process.exit(1);
+let distTag = 'latest';
+if (tagName) {
+	try {
+		distTag = parseAgentReleaseVersion(tagName, packageVersion).distTag;
+	} catch (error) {
+		console.error(error instanceof Error ? error.message : String(error));
+		process.exit(1);
+	}
 }
 
-const npmArgs = ['publish', '.', '--access', 'public'];
+const publishTarget = extraArgs[0]?.endsWith('.tgz') ? resolve(packageRoot, extraArgs.shift()!) : '.';
+const npmArgs = ['publish', publishTarget, '--access', 'public', '--tag', distTag];
 if (process.env.GITHUB_ACTIONS === 'true') npmArgs.push('--provenance');
 npmArgs.push(...extraArgs);
 

--- a/scripts/packages/release-version.ts
+++ b/scripts/packages/release-version.ts
@@ -1,0 +1,8 @@
+export function parseAgentReleaseVersion(tagName: string, packageVersion: string) {
+	if (tagName !== packageVersion) {
+		throw new Error(`Release tag "${tagName}" does not match @treeseed/agent version "${packageVersion}".`);
+	}
+	if (/^\d+\.\d+\.\d+$/u.test(tagName)) return { channel: 'stable' as const, distTag: 'latest' as const };
+	if (/^\d+\.\d+\.\d+-rc\.\d+$/u.test(tagName)) return { channel: 'prerelease' as const, distTag: 'rc' as const };
+	throw new Error(`Release tag "${tagName}" must be an exact stable or rc.N semantic version.`);
+}

--- a/tests/contract/package/release-version.test.ts
+++ b/tests/contract/package/release-version.test.ts
@@ -1,0 +1,15 @@
+import { describe, expect, it } from 'vitest';
+import { parseAgentReleaseVersion } from '../../../scripts/packages/release-version.ts';
+
+describe('Agent release version policy', () => {
+	it('routes exact stable and RC versions to isolated npm dist-tags', () => {
+		expect(parseAgentReleaseVersion('0.13.0', '0.13.0')).toEqual({ channel: 'stable', distTag: 'latest' });
+		expect(parseAgentReleaseVersion('0.13.0-rc.1', '0.13.0-rc.1')).toEqual({ channel: 'prerelease', distTag: 'rc' });
+	});
+
+	it('rejects mismatches and unsupported prerelease channels', () => {
+		expect(() => parseAgentReleaseVersion('0.13.0-rc.1', '0.13.0-rc.2')).toThrow(/does not match/u);
+		expect(() => parseAgentReleaseVersion('0.13.0-beta.1', '0.13.0-beta.1')).toThrow(/stable or rc\.N/u);
+		expect(() => parseAgentReleaseVersion('v0.13.0', 'v0.13.0')).toThrow(/stable or rc\.N/u);
+	});
+});


### PR DESCRIPTION
## Outcome

Adds an npm-only semantic prerelease path for Agent RCs while keeping production capacity-provider images disabled.

## Work authority

- Work item / Issue: Closes #9
- Proposal / decision: Gate 2 Agent semantic-RC publication prerequisite
- Assignment / checkpoint: Pre-agent implementation; no live TreeSeed assignment or workday
- Actor: OpenAI Codex under Adrian Webb's direction
- Human authority: Adrian Webb
- Agent / capacity provider: Codex development agent; no TreeSeed capacity-provider lease
- Exact base ref: `staging` at `77d7b2c40fad70b13ce5f7fb1dd3f3697baa3a7b`
- Exact head ref: `codex/agent-rc-publication` at `632969a1a88a50966a267fd31965a61ebeecc68b`

Contributor mode (select one):

- [ ] Human-authored
- [x] Agent-assisted under human authority
- [ ] Agent-authored under human authority

## Plan

1. Accept only exact stable or `rc.N` semantic tags that equal `package.json`.
2. Route RCs only to npm `rc`; retain stable `latest` behavior.
3. Verify and upload the exact tarball before publication, then compare registry tar bytes and dist-tags after publication.
4. Create a GitHub prerelease for RCs and skip all production image jobs.
5. Pin credential-bearing workflow actions to immutable commits.

Status: implemented and verified; ready for governed staging merge.

## Changes and commits

- `632969a1a88a50966a267fd31965a61ebeecc68b` — `ci: add npm-only Agent prerelease`
- Adds shared release-version policy, tests, exact artifact upload/read-back, `latest` drift protection, prerelease creation, and immutable action identities.

## Verification

- Release-version and package-contract tests: 14/14 passed.
- `npm run build:dist` passed.
- `GITHUB_REF_NAME=0.13.0-rc.1 npm run release:check-tag` passed.
- Publish workflow YAML parsed.
- Exact packed-tar dry-run selected npm dist-tag `rc`, public access, and the supplied tarball; no network publication occurred locally.
- `git diff --check` passed.
- Hosted push Verify run `32481213974` passed at the exact head.
- Hosted PR Verify run `32481251442` passed at the exact head.

## Risk and rollback

RC npm publication gains trusted automation, but production images remain guarded by the existing stable-tag-only jobs. The workflow fails on tag/version mismatch, unsupported prerelease channels, changed npm `latest`, registry non-convergence, or tarball digest mismatch. Roll back by reverting this commit before creating the RC tag.

## Completion summary

Agent RC1 can now be published independently as a semantic npm prerelease without promoting any production image. Remaining work is hosted verification, staging merge/read-back, tag publication/read-back, and cleanup.

## Submission checklist

- [x] The change is bounded to the stated work item and target repository.
- [x] Exact base and head refs are recorded and the branch is ready for review.
- [x] Verification and compatibility evidence are recorded above.
- [x] No plaintext secrets, credentials, machine state, or unrelated residue are included.
- [x] Plan, status, commits, and completion summary form a complete durable record.
- [x] Rollback or recovery steps are documented and executable.
