### PR TITLE
fix: retry npm artifact visibility

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -55,12 +55,19 @@ jobs:
         run: |
           set -euo pipefail
           deadline=$((SECONDS + 180))
+          temp="$(mktemp -d)"
           while true; do
             published="$(npm view "@treeseed/agent@${GITHUB_REF_NAME}" version 2>/dev/null || true)"
             channel="latest"
             if [[ "${GITHUB_REF_NAME}" == *-rc.* ]]; then channel="rc"; fi
             tagged="$(npm view "@treeseed/agent" "dist-tags.${channel}" 2>/dev/null || true)"
-            if [[ "${published}" == "${GITHUB_REF_NAME}" && "${tagged}" == "${GITHUB_REF_NAME}" ]]; then break; fi
+            rm -f "${temp}"/*.tgz
+            if [[ "${published}" == "${GITHUB_REF_NAME}" && "${tagged}" == "${GITHUB_REF_NAME}" ]] \
+              && npm pack "@treeseed/agent@${GITHUB_REF_NAME}" --ignore-scripts --pack-destination "${temp}" >/dev/null 2>&1; then
+              actual="$(sha256sum "${temp}"/*.tgz | awk '{print $1}')"
+              [[ "${actual}" == "${EXPECTED_SHA256}" ]] || { echo "published tarball digest mismatch" >&2; exit 1; }
+              break
+            fi
             if (( SECONDS >= deadline )); then echo "npm read-back did not converge" >&2; exit 1; fi
             sleep 3
           done
@@ -68,10 +75,6 @@ jobs:
             latest="$(npm view @treeseed/agent dist-tags.latest)"
             [[ "${latest}" == "${EXPECTED_LATEST}" ]] || { echo "prerelease changed npm latest" >&2; exit 1; }
           fi
-          temp="$(mktemp -d)"
-          npm pack "@treeseed/agent@${GITHUB_REF_NAME}" --ignore-scripts --pack-destination "${temp}" >/dev/null
-          actual="$(sha256sum "${temp}"/*.tgz | awk '{print $1}')"
-          [[ "${actual}" == "${EXPECTED_SHA256}" ]] || { echo "published tarball digest mismatch" >&2; exit 1; }
 
   build:
     if: startsWith(github.ref, 'refs/tags/') && !contains(github.ref_name, '-')

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@treeseed/agent",
-  "version": "0.13.0-rc.3",
+  "version": "0.13.0-rc.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@treeseed/agent",
-      "version": "0.13.0-rc.3",
+      "version": "0.13.0-rc.4",
       "license": "Apache-2.0",
       "dependencies": {
         "@treeseed/sdk": "0.13.0-rc.19",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@treeseed/agent",
-  "version": "0.13.0-rc.3",
+  "version": "0.13.0-rc.4",
   "description": "Treeseed agent service runtime package.",
   "license": "Apache-2.0",
   "repository": {


### PR DESCRIPTION
## Outcome

Makes Agent prerelease settlement wait for the immutable registry tarball—not only version and dist-tag metadata—before accepting publication, then advances to the next unused RC.

## Work authority

- Work item / Issue: Closes #15
- Proposal / decision: Platform TreeDX control-plane proxy cutover ledger
- Assignment / checkpoint: Agent RC publication recovery checkpoint
- Actor: Codex under adrianwebb
- Human authority: adrianwebb
- Agent / capacity provider: Codex local development session; no live TreeSeed provider execution
- Exact base ref: staging 7cf3b8a856f70a2d8bc4b7f35553a23ecb1ee0a7
- Exact head ref: codex/agent-release-readback a7e0a8ceec844454fce24cce63cc00247c0b8988

Contributor mode (select one):

- [ ] Human-authored
- [x] Agent-assisted under human authority
- [ ] Agent-authored under human authority

## Plan

Preserve the RC3 artifact, diagnose its transient read-back failure, retry version/tag/tar visibility under the existing deadline, keep exact digest/latest checks unchanged, and publish the next immutable RC only after hosted verification.

## Changes and commits

- a7e0a8ceec844454fce24cce63cc00247c0b8988 retries the exact registry pack inside the bounded convergence loop and advances source/lock to 0.13.0-rc.4.
- Digest mismatch still fails immediately; only absent registry visibility is retried.

## Verification

- RC3 independent npm pack returns the workflow expected SHA-256 3284f3676b049930714603b149bbdbb0abf11b4d9029a0a45f0f16e7764a4532.
- The corrected bounded loop passed locally against RC3.
- Workflow YAML parsing passed.
- Exact lock records Agent RC4 and SDK RC19.
- Architecture/length policy and distribution build passed.
- No production/latest mutation, legacy suite, live agent, or paid reviewer ran.

## Risk and rollback

Risk is confined to release evidence timing. Roll back by reverting a7e0a8ceec844454fce24cce63cc00247c0b8988 before tagging. RC3 remains immutable and npm latest remains 0.12.58.

## Completion summary

RC3 proved package correctness but lacked one wholly green publication receipt because npm metadata preceded tarball visibility. This correction preserves strict evidence and prepares RC4. Pending ordinary checks, staging read-back, and one complete RC4 tag publication.

## Submission checklist

- [x] The change is bounded to the stated work item and target repository.
- [x] Exact base and head refs are recorded and the branch is ready for review.
- [x] Verification and compatibility evidence are recorded above.
- [x] No plaintext secrets, credentials, machine state, or unrelated residue are included.
- [x] Plan, status, commits, and completion summary form a complete durable record.
- [x] Rollback or recovery steps are documented and executable.