### PR TITLE
Adopt the unified capacity-provider battery runtime

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,15 +1,15 @@
 {
   "name": "@treeseed/agent",
-  "version": "0.13.0-rc.4",
+  "version": "0.13.0-rc.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@treeseed/agent",
-      "version": "0.13.0-rc.4",
+      "version": "0.13.0-rc.5",
       "license": "Apache-2.0",
       "dependencies": {
-        "@treeseed/sdk": "0.13.0-rc.19",
+        "@treeseed/sdk": "0.13.0-rc.20",
         "esbuild": "0.28.2",
         "typescript": "^5.9.3",
         "yaml": "^2.8.1"
@@ -727,9 +727,9 @@
       "license": "MIT"
     },
     "node_modules/@treeseed/sdk": {
-      "version": "0.13.0-rc.19",
-      "resolved": "https://registry.npmjs.org/@treeseed/sdk/-/sdk-0.13.0-rc.19.tgz",
-      "integrity": "sha512-PfDj/Jp33galCOz+E/I3zjAMlLsMtWQMLIs5Tf92NatTJMQfOgMu6G6bYCF2h1najMU4f2ogStKLiVAiQvYsug==",
+      "version": "0.13.0-rc.20",
+      "resolved": "https://registry.npmjs.org/@treeseed/sdk/-/sdk-0.13.0-rc.20.tgz",
+      "integrity": "sha512-XM2ewAUACIO/umqZEsKlfdJxaDZW8IyMnH5pSoS7vcySKbMb/2bGPwJpfIIuNui9vMAkQ7KwkoIEV5fHXiFUvQ==",
       "license": "Apache-2.0",
       "dependencies": {
         "@treeseed/treedx": "0.3.0-rc.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@treeseed/agent",
-  "version": "0.13.0-rc.4",
+  "version": "0.13.0-rc.5",
   "description": "Treeseed agent service runtime package.",
   "license": "Apache-2.0",
   "repository": {
@@ -62,7 +62,7 @@
     "test:provider-runtime": "npm run test:modern"
   },
   "dependencies": {
-    "@treeseed/sdk": "0.13.0-rc.19",
+    "@treeseed/sdk": "0.13.0-rc.20",
     "esbuild": "0.28.2",
     "typescript": "^5.9.3",
     "yaml": "^2.8.1"

--- a/src/provider/configuration/config.ts
+++ b/src/provider/configuration/config.ts
@@ -1,7 +1,7 @@
 import { existsSync, readFileSync } from 'node:fs';
 import type { CapacityProviderManifestV3 } from '@treeseed/sdk/capacity-provider';
 
-export type ProviderRole = 'manager' | 'runner' | 'doctor' | 'healthcheck' | 'plan' | 'version';
+export type ProviderRole = 'manager' | 'runner' | 'enroll' | 'doctor' | 'healthcheck' | 'plan' | 'version';
 
 const packageVersion = String(JSON.parse(readFileSync(new URL('../../../package.json', import.meta.url), 'utf8')).version);
 

--- a/src/provider/configuration/config.ts
+++ b/src/provider/configuration/config.ts
@@ -1,5 +1,5 @@
 import { existsSync, readFileSync } from 'node:fs';
-import type { CapacityProviderManifestV2 } from '@treeseed/sdk/capacity-provider';
+import type { CapacityProviderManifestV3 } from '@treeseed/sdk/capacity-provider';
 
 export type ProviderRole = 'manager' | 'runner' | 'doctor' | 'healthcheck' | 'plan' | 'version';
 
@@ -29,8 +29,9 @@ export interface ProviderConnectionRuntimeContext extends ProviderHostRuntimeCon
   membershipId: string;
   accessToken: string;
   accessTokenProvider?: (minimumValidityMs?: number) => Promise<string>;
-  defaultExecutionProviderId?: string;
-  executionProviders?: CapacityProviderManifestV2['executionProviders'];
+  adapters: CapacityProviderManifestV3['adapters'];
+  lanes: CapacityProviderManifestV3['lanes'];
+  providerCapacity: CapacityProviderManifestV3['capacity'];
 }
 
 function value(env: NodeJS.ProcessEnv, name: string) {

--- a/src/provider/configuration/manifest.ts
+++ b/src/provider/configuration/manifest.ts
@@ -2,9 +2,9 @@ import { chmod, mkdir, readFile, rename, unlink, writeFile } from 'node:fs/promi
 import { dirname, isAbsolute, resolve } from 'node:path';
 import { parse as parseYaml, stringify as stringifyYaml } from 'yaml';
 import {
-	validateCapacityProviderManifestV2,
+	validateCapacityProviderManifestV3,
 	type CapacityProviderJoinInput,
-	type CapacityProviderManifestV2,
+	type CapacityProviderManifestV3,
 	type ProviderConnectionConfig,
 } from '@treeseed/sdk/capacity-provider';
 
@@ -13,7 +13,7 @@ export const DEFAULT_PROVIDER_MANIFEST = 'treeseed.capacity-provider.yaml';
 export interface LoadedProviderManifest {
 	path: string;
 	directory: string;
-	manifest: CapacityProviderManifestV2;
+	manifest: CapacityProviderManifestV3;
 }
 
 export interface ProviderSecretResolver {
@@ -26,14 +26,14 @@ function diagnosticMessage(diagnostics: Array<{ path: string; message: string }>
 
 export async function loadProviderManifest(path = process.env.TREESEED_CAPACITY_PROVIDER_MANIFEST || DEFAULT_PROVIDER_MANIFEST): Promise<LoadedProviderManifest> {
 	const absolute = resolve(path);
-	const parsed = parseYaml(await readFile(absolute, 'utf8')) as CapacityProviderManifestV2;
-	const validation = validateCapacityProviderManifestV2(parsed);
+	const parsed = parseYaml(await readFile(absolute, 'utf8')) as CapacityProviderManifestV3;
+	const validation = validateCapacityProviderManifestV3(parsed);
 	if (!validation.ok) throw new Error(`Invalid capacity provider manifest: ${diagnosticMessage(validation.diagnostics)}`);
 	return { path: absolute, directory: dirname(absolute), manifest: parsed };
 }
 
-export async function writeProviderManifest(loaded: LoadedProviderManifest, manifest: CapacityProviderManifestV2) {
-	const validation = validateCapacityProviderManifestV2(manifest);
+export async function writeProviderManifest(loaded: LoadedProviderManifest, manifest: CapacityProviderManifestV3) {
+	const validation = validateCapacityProviderManifestV3(manifest);
 	if (!validation.ok) throw new Error(`Invalid capacity provider manifest: ${diagnosticMessage(validation.diagnostics)}`);
 	const temporary = `${loaded.path}.${process.pid}.${Date.now()}.tmp`;
 	await writeFile(temporary, stringifyYaml(manifest), { encoding: 'utf8', mode: 0o600, flag: 'wx' });

--- a/src/provider/coordination/coordinator.ts
+++ b/src/provider/coordination/coordinator.ts
@@ -160,7 +160,7 @@ export class CapacityProviderCoordinator {
 		return { connectionId: connection.id, status: 'connected', teamId: connection.teamId, providerId: connection.providerId, membershipId: connection.membershipId, runtime: { connection, controlPlaneUrl, controlPlaneAudience, teamId: connection.teamId, providerId: connection.providerId, membershipId: connection.membershipId, credentialId: connection.membershipCredentialId, accessToken } };
 	}
 
-	async beginJoin(join: CapacityProviderJoinInput): Promise<ProviderConnectionResult> {
+	async beginJoin(join: CapacityProviderJoinInput, oneTimeRegistrationKey?: string): Promise<ProviderConnectionResult> {
 		if (this.loaded.manifest.connections.some((connection) => connection.id === join.id)) throw new Error(`Provider connection ${join.id} is already approved and configured.`);
 		const existing = await readProviderConnectionState(this.dataDir, join.id);
 		if (existing?.registrationRequestId) return this.pollRegistrationStatus(join.id);
@@ -171,7 +171,7 @@ export class CapacityProviderCoordinator {
 		const unsigned = unsignedRegistration(this.loaded.manifest, join, identity);
 		const proof = await this.proof({ audience: controlPlaneAudience, method: 'POST', path: providerOperationPath(CONTROL_PLANE_OPERATIONS.providers.register), body: unsigned, identity });
 		const submission: ProviderRegistrationSubmission = { ...unsigned, proof };
-		const registrationKey = await resolveProviderSecret(join.registrationKeyRef, { env: this.options.env, baseDirectory: this.loaded.directory, dataDirectory: this.dataDir, resolver: this.options.secretResolver });
+		const registrationKey = oneTimeRegistrationKey ?? await resolveProviderSecret(join.registrationKeyRef, { env: this.options.env, baseDirectory: this.loaded.directory, dataDirectory: this.dataDir, resolver: this.options.secretResolver });
 		const request = await client.register(registrationKey, submission, `register:${join.id}`);
 		const state = nextState(join.id, controlPlaneUrl, null, { serverProfile: join.serverProfile ?? null, controlPlaneAudience, offer: join.offer, teamId: request.teamId, providerId: request.providerId, registrationRequestId: request.id, registrationStatus: request.status });
 		await writeProviderConnectionState(this.dataDir, state);

--- a/src/provider/coordination/coordinator.ts
+++ b/src/provider/coordination/coordinator.ts
@@ -1,6 +1,6 @@
 import { randomUUID } from 'node:crypto';
 import type {
-	CapacityProviderManifestV2,
+	CapacityProviderManifestV3,
 	CapacityProviderJoinInput,
 	ProviderAccessTokenIssue,
 	ProviderConnectionConfig,
@@ -58,7 +58,7 @@ interface CoordinatorIdentity {
 	publicJwk: Awaited<ReturnType<typeof loadCapacityProviderIdentity>>['publicJwk'];
 }
 
-function unsignedRegistration(manifest: CapacityProviderManifestV2, connection: CapacityProviderJoinInput, identity: CoordinatorIdentity) {
+function unsignedRegistration(manifest: CapacityProviderManifestV3, connection: CapacityProviderJoinInput, identity: CoordinatorIdentity) {
 	return {
 		schemaVersion: 1 as const,
 		displayName: manifest.identity.displayName,

--- a/src/provider/execution/executor-loader.ts
+++ b/src/provider/execution/executor-loader.ts
@@ -3,6 +3,7 @@ import { isAbsolute, resolve } from 'node:path';
 import type { CapacityProviderManifestV3 } from '@treeseed/sdk/capacity-provider';
 import type { ProviderHostRuntimeConfig } from '../configuration/config.ts';
 import type { AgentExecutor, AgentExecutorModule } from './contracts.ts';
+import { createProcessIsolatedExecutor } from './process-executor.ts';
 
 const cache = new Map<string, Promise<AgentExecutorModule>>();
 
@@ -18,9 +19,11 @@ async function loadModule(specifier: string) {
   return module;
 }
 
-export async function resolveAgentExecutor(config: ProviderHostRuntimeConfig, adapter: CapacityProviderManifestV3['adapters'][number]): Promise<AgentExecutor | null> {
+export async function resolveAgentExecutor(config: ProviderHostRuntimeConfig, adapter: CapacityProviderManifestV3['adapters'][number], manifest: CapacityProviderManifestV3): Promise<AgentExecutor | null> {
   const module = adapter.module ?? config.executorModule;
   if (!module) return null;
+  if (adapter.isolation === 'process') return createProcessIsolatedExecutor(config, manifest, adapter, module);
+  if ((adapter.credentialProfiles?.length ?? 0) > 0) throw new Error(`Worker-isolated adapter ${adapter.id} may not receive credential profiles.`);
   const executor = await (await loadModule(module)).createAgentExecutor({ executionProviderId: adapter.id, environment: config.environment });
   if (!executor || typeof executor.execute !== 'function' || typeof executor.observe !== 'function') {
     throw new Error('Agent executor module returned an invalid executor.');

--- a/src/provider/execution/executor-loader.ts
+++ b/src/provider/execution/executor-loader.ts
@@ -1,5 +1,6 @@
 import { pathToFileURL } from 'node:url';
 import { isAbsolute, resolve } from 'node:path';
+import type { CapacityProviderManifestV3 } from '@treeseed/sdk/capacity-provider';
 import type { ProviderHostRuntimeConfig } from '../configuration/config.ts';
 import type { AgentExecutor, AgentExecutorModule } from './contracts.ts';
 
@@ -17,9 +18,10 @@ async function loadModule(specifier: string) {
   return module;
 }
 
-export async function resolveAgentExecutor(config: ProviderHostRuntimeConfig, executionProviderId: string): Promise<AgentExecutor | null> {
-  if (!config.executorModule) return null;
-  const executor = await (await loadModule(config.executorModule)).createAgentExecutor({ executionProviderId, environment: config.environment });
+export async function resolveAgentExecutor(config: ProviderHostRuntimeConfig, adapter: CapacityProviderManifestV3['adapters'][number]): Promise<AgentExecutor | null> {
+  const module = adapter.module ?? config.executorModule;
+  if (!module) return null;
+  const executor = await (await loadModule(module)).createAgentExecutor({ executionProviderId: adapter.id, environment: config.environment });
   if (!executor || typeof executor.execute !== 'function' || typeof executor.observe !== 'function') {
     throw new Error('Agent executor module returned an invalid executor.');
   }

--- a/src/provider/execution/process-executor-worker.ts
+++ b/src/provider/execution/process-executor-worker.ts
@@ -1,0 +1,56 @@
+import { pathToFileURL } from 'node:url';
+import { isAbsolute, resolve } from 'node:path';
+import type { AgentExecutor, AgentExecutorModule, AssignmentTreeDxFacade } from './contracts.ts';
+
+let executor: AgentExecutor | null = null;
+let initializing: Promise<void> | null = null;
+const controllers = new Map<string, AbortController>();
+const calls = new Map<string, { resolve(value: unknown): void; reject(error: Error): void }>();
+let callSequence = 0;
+
+async function initialize(message: any) {
+	const specifier = String(message.module);
+	const key = isAbsolute(specifier) || specifier.startsWith('.') ? pathToFileURL(resolve(specifier)).href : specifier;
+	const loaded = await import(key) as AgentExecutorModule;
+	if (typeof loaded.createAgentExecutor !== 'function') throw new Error('Executor module must export createAgentExecutor().');
+	executor = await loaded.createAgentExecutor({ executionProviderId: String(message.executionProviderId), environment: String(message.environment) });
+}
+
+function treeDx(requestId: string, snapshot: any): AssignmentTreeDxFacade {
+	return {
+		projectId: String(snapshot.projectId), repositoryId: snapshot.repositoryId ?? null, workspaceId: snapshot.workspaceId ?? null,
+		invoke(operationId, input, options) {
+			return new Promise((resolve, reject) => {
+				const callId = `${requestId}:${++callSequence}`;
+				calls.set(callId, { resolve, reject });
+				process.send?.({ type: 'treedx', requestId, callId, operationId, input, idempotencyKey: options?.idempotencyKey });
+			});
+		},
+	};
+}
+
+process.on('message', async (message: any) => {
+	if (message?.type === 'treedx-result') {
+		const call = calls.get(String(message.callId));
+		if (!call) return;
+		calls.delete(String(message.callId));
+		if (message.ok) call.resolve(message.value); else call.reject(new Error(String(message.error)));
+		return;
+	}
+	if (message?.type === 'cancel') return controllers.get(String(message.id))?.abort();
+	const id = String(message?.id ?? '');
+	try {
+		if (message.type === 'initialize') { initializing = initialize(message); return await initializing; }
+		if (initializing) await initializing;
+		if (!executor) throw new Error('Executor process is not initialized.');
+		if (message.type === 'observe') return process.send?.({ id, ok: true, value: await executor.observe() });
+		if (message.type === 'execute') {
+			const controller = new AbortController(); controllers.set(id, controller);
+			const request = message.request;
+			const value = await executor.execute({ ...request, treeDx: treeDx(id, request.treeDx), signal: controller.signal });
+			controllers.delete(id);
+			return process.send?.({ id, ok: true, value });
+		}
+	} catch (error) { process.send?.({ id, ok: false, error: error instanceof Error ? error.message : String(error) }); }
+});
+process.on('disconnect', () => process.exit(0));

--- a/src/provider/execution/process-executor.ts
+++ b/src/provider/execution/process-executor.ts
@@ -1,0 +1,69 @@
+import { fork } from 'node:child_process';
+import { existsSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import type { CapacityProviderManifestV3 } from '@treeseed/sdk/capacity-provider';
+import type { ProviderHostRuntimeConfig } from '../configuration/config.ts';
+import type { AgentExecutionRequest, AgentExecutionResult, AgentExecutor, AgentExecutorObservation } from './contracts.ts';
+
+type Adapter = CapacityProviderManifestV3['adapters'][number];
+type Pending = { resolve(value: unknown): void; reject(error: Error): void; request?: AgentExecutionRequest };
+
+function workerEntry() {
+	const javascript = fileURLToPath(new URL('./process-executor-worker.js', import.meta.url));
+	if (existsSync(javascript)) return { file: javascript, execArgv: [] as string[] };
+	return { file: fileURLToPath(new URL('./process-executor-worker.ts', import.meta.url)), execArgv: ['--import', 'tsx'] };
+}
+
+function projectedEnvironment(config: ProviderHostRuntimeConfig, manifest: CapacityProviderManifestV3, adapter: Adapter) {
+	const env: NodeJS.ProcessEnv = { NODE_ENV: config.environment, LANG: process.env.LANG, TZ: process.env.TZ };
+	for (const profileId of adapter.credentialProfiles ?? []) {
+		const profile = manifest.credentialProfiles?.find((candidate) => candidate.id === profileId);
+		if (!profile) throw new Error(`Adapter ${adapter.id} references unknown credential profile ${profileId}.`);
+		if (profile.source !== 'process-environment') throw new Error(`Adapter ${adapter.id} requires unsupported credential source ${profile.source}.`);
+		const value = process.env[profile.reference];
+		if (profile.required && !value) throw new Error(`Required credential profile ${profile.id} is unavailable.`);
+		if (value) env[profile.reference] = value;
+	}
+	return env;
+}
+
+export function createProcessIsolatedExecutor(config: ProviderHostRuntimeConfig, manifest: CapacityProviderManifestV3, adapter: Adapter, module: string): AgentExecutor {
+	const entry = workerEntry();
+	const child = fork(entry.file, [], { env: projectedEnvironment(config, manifest, adapter), execArgv: entry.execArgv, stdio: ['ignore', 'ignore', 'ignore', 'ipc'], serialization: 'advanced' });
+	let sequence = 0;
+	const pending = new Map<string, Pending>();
+	const rejectAll = (message: string) => { for (const request of pending.values()) request.reject(new Error(message)); pending.clear(); };
+	child.once('error', (error) => rejectAll(`Isolated executor failed: ${error.message}`));
+	child.once('exit', (code, signal) => rejectAll(`Isolated executor exited (${code ?? signal ?? 'unknown'}).`));
+	child.on('message', async (message: any) => {
+		if (message?.type === 'treedx') {
+			const request = pending.get(String(message.requestId))?.request;
+			if (!request) return child.send({ type: 'treedx-result', callId: message.callId, ok: false, error: 'assignment_request_unavailable' });
+			try {
+				const value = await request.treeDx.invoke(String(message.operationId), message.input ?? {}, { idempotencyKey: message.idempotencyKey });
+				child.send({ type: 'treedx-result', callId: message.callId, ok: true, value });
+			} catch (error) { child.send({ type: 'treedx-result', callId: message.callId, ok: false, error: error instanceof Error ? error.message : String(error) }); }
+			return;
+		}
+		const id = String(message?.id ?? '');
+		const request = pending.get(id);
+		if (!request) return;
+		pending.delete(id);
+		if (message.ok) request.resolve(message.value); else request.reject(new Error(String(message.error ?? 'Isolated executor request failed.')));
+	});
+	const invoke = <T>(type: 'observe' | 'execute', value?: AgentExecutionRequest) => new Promise<T>((resolve, reject) => {
+		const id = `${adapter.id}:${++sequence}`;
+		pending.set(id, { resolve: resolve as (value: unknown) => void, reject, request: value });
+		child.send({ type, id, request: value ? { assignment: value.assignment, assignmentId: value.assignmentId, leaseToken: value.leaseToken, runnerId: value.runnerId,
+			treeDx: { projectId: value.treeDx.projectId, repositoryId: value.treeDx.repositoryId, workspaceId: value.treeDx.workspaceId } } : undefined });
+		if (value?.signal) value.signal.addEventListener('abort', () => child.send({ type: 'cancel', id }), { once: true });
+	});
+	child.send({ type: 'initialize', module, executionProviderId: adapter.id, environment: config.environment });
+	const proxy = {
+		id: adapter.id,
+		observe: () => invoke<AgentExecutorObservation>('observe'),
+		execute: (request: AgentExecutionRequest) => invoke<AgentExecutionResult>('execute', request),
+		shutdown: () => child.kill('SIGTERM'),
+	};
+	return proxy;
+}

--- a/src/provider/lifecycle/entrypoint.ts
+++ b/src/provider/lifecycle/entrypoint.ts
@@ -3,7 +3,7 @@
 import { providerRuntimeVersion, resolveProviderConfig, type ProviderRole } from '../configuration/config.ts';
 import { writeProviderRuntimeStatus } from '../runtime/runtime-status.ts';
 
-const ROLES = ['manager', 'runner', 'doctor', 'healthcheck', 'plan', 'version'] as const satisfies ProviderRole[];
+const ROLES = ['manager', 'runner', 'enroll', 'doctor', 'healthcheck', 'plan', 'version'] as const satisfies ProviderRole[];
 
 function args() {
 	return process.argv.slice(2);
@@ -74,6 +74,17 @@ function sleep(ms: number) {
 	});
 }
 
+async function stdinJson() {
+	let value = '';
+	for await (const chunk of process.stdin) {
+		value += String(chunk);
+		if (value.length > 64 * 1024) throw new Error('Provider enrollment input is too large.');
+	}
+	const parsed = JSON.parse(value);
+	if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) throw new Error('Provider enrollment input must be a JSON object.');
+	return parsed as Record<string, unknown>;
+}
+
 async function runLoop(role: 'manager' | 'runner', dataDirectory: string, intervalSeconds: number, runOnce: () => Promise<unknown>) {
 	emit(okPayload(role, {
 		status: 'running',
@@ -131,6 +142,30 @@ async function main() {
 	if (role === 'plan') {
 		const { buildProviderPlan } = await import('./lifecycle.ts');
 		emit(await buildProviderPlan(config));
+		return;
+	}
+	if (role === 'enroll') {
+		if (!config.manifestPath) throw new Error('A capacity provider manifest is required for enrollment.');
+		const input = await stdinJson();
+		const { createCapacityProviderCoordinator } = await import('../teams/multi-team-runtime.ts');
+		const coordinator = await createCapacityProviderCoordinator(config);
+		const connectionId = String(input.connectionId ?? `local-${String(input.teamId ?? '')}`);
+		if (input.action === 'complete') {
+			const receipt = await coordinator.exchangeRegistrationCredential(connectionId);
+			emit({ ok: true, connectionId, status: receipt.status, teamId: receipt.teamId, providerId: receipt.providerId, membershipId: receipt.membershipId });
+			return;
+		}
+		const enrollmentToken = String(input.enrollmentToken ?? '');
+		const teamId = String(input.teamId ?? '');
+		const loaded = await import('../configuration/manifest.ts').then(({ loadProviderManifest }) => loadProviderManifest(config.manifestPath!));
+		if (!enrollmentToken || !teamId) throw new Error('Provider enrollment requires a team and one-time token.');
+		const receipt = await coordinator.beginJoin({ id: connectionId,
+			...(input.serverProfile ? { serverProfile: String(input.serverProfile) } : { controlPlaneUrl: String(input.controlPlaneUrl ?? '') }),
+			controlPlaneAudience: String(input.controlPlaneAudience ?? input.controlPlaneUrl ?? ''), registrationKeyRef: 'memory://one-time',
+			offer: { maxConcurrentRunners: loaded.manifest.capacity.maxConcurrentWorkers,
+				capabilities: [...new Set(loaded.manifest.adapters.flatMap((adapter) => adapter.capabilities ?? []))],
+				metadata: { manifestGeneration: loaded.manifest.configuration.generation } } }, enrollmentToken);
+		emit({ ok: true, connectionId, status: receipt.status, teamId: receipt.teamId, providerId: receipt.providerId, requestId: receipt.requestId });
 		return;
 	}
 	if (role === 'manager') {

--- a/src/provider/lifecycle/lifecycle.ts
+++ b/src/provider/lifecycle/lifecycle.ts
@@ -39,8 +39,10 @@ export async function buildProviderPlan(config: ProviderHostRuntimeConfig) {
 
 export interface ProviderAvailabilityProjection {
 	offer?: ProviderSupplyOffer;
-	executionProviders: Array<Record<string, unknown>>;
-	activeRunners?: number;
+	adapters: Array<Record<string, unknown>>;
+	lanes: Array<Record<string, unknown>>;
+	capacity: Record<string, unknown>;
+	activeWorkers?: number;
 	constraints?: Record<string, unknown>;
 }
 
@@ -55,10 +57,13 @@ export async function publishProviderAvailability(
 		ttlSeconds: 90,
 		environment: config.environment,
 		status: 'open',
-		executionProviders: availability.executionProviders,
+		adapters: availability.adapters,
+		lanes: availability.lanes,
+		capacity: availability.capacity,
 		capabilities: discoverProviderCapabilities(config),
-		nativeLimits: discoverProviderBudgets(config),
-		runnerPressure: { activeRunners: availability.activeRunners ?? 0, maxConcurrentRunners: config.maxConcurrentRunners },
+		runnerPressure: { activeWorkers: availability.activeWorkers ?? 0,
+			maxConcurrentWorkers: Number(availability.capacity.maxConcurrentWorkers ?? config.maxConcurrentRunners),
+			activeAssignmentIds: [] },
 		constraints: { outboundOnly: true, ...availability.constraints },
 		metadata: {
 			source: '@treeseed/agent/provider-manager',

--- a/src/provider/teams/multi-team-runtime.ts
+++ b/src/provider/teams/multi-team-runtime.ts
@@ -20,8 +20,7 @@ function text(...values: unknown[]) {
 function context(
 	config: ProviderHostRuntimeConfig,
 	runtime: ProviderConnectionRuntime,
-	executionProviders: ProviderConnectionRuntimeContext['executionProviders'],
-	defaultExecutionProviderId?: string,
+	manifest: Pick<Awaited<ReturnType<typeof loadProviderManifest>>['manifest'], 'adapters' | 'lanes' | 'capacity'>,
 ): ProviderConnectionRuntimeContext {
 	return {
 		...config,
@@ -32,8 +31,9 @@ function context(
 		providerId: runtime.providerId,
 		membershipId: runtime.membershipId,
 		accessToken: runtime.accessToken.accessToken,
-		executionProviders,
-		defaultExecutionProviderId,
+		adapters: manifest.adapters,
+		lanes: manifest.lanes,
+		providerCapacity: manifest.capacity,
 		env: { ...config.env, TREESEED_API_BASE_URL: runtime.controlPlaneUrl },
 	};
 }
@@ -76,25 +76,30 @@ export async function runMultiTeamProviderManager(
 		if (!connection.runtime) {
 			return { ok: connection.status !== 'error', connectionId: connection.connectionId, status: connection.status };
 		}
-		const runtime = context(config, connection.runtime, loaded.manifest.executionProviders, loaded.manifest.defaultExecutionProviderId);
-		const providers = await Promise.all(loaded.manifest.executionProviders.map(async (provider) => {
-			const executor = await resolveAgentExecutor(config, provider.id).catch(() => null);
+		const runtime = context(config, connection.runtime, loaded.manifest);
+		const adapters = await Promise.all(loaded.manifest.adapters.map(async (adapter) => {
+			const executor = await resolveAgentExecutor(config, adapter).catch(() => null);
 			const observation = executor
 				? await executor.observe().catch((error) => ({ available: false, reason: error instanceof Error ? error.message : String(error) }))
 				: { available: false, reason: 'executor_not_configured' };
 			return {
-				id: provider.id,
-				adapter: provider.adapter,
-				nativeLimits: provider.nativeLimits,
-				capabilities: provider.capabilities ?? [],
+				id: adapter.id,
+				adapter: adapter.adapter,
+				isolation: adapter.isolation,
+				laneIds: adapter.laneIds,
+				maxConcurrentWorkers: adapter.maxConcurrentWorkers,
+				nativeLimits: adapter.nativeLimits,
+				capabilities: adapter.capabilities ?? [],
 				status: observation.available ? 'available' : 'unavailable',
 				observations: observation,
 			};
 		}));
 		return publishProviderAvailability(runtime, {
 			offer: connection.runtime.connection.offer,
-			executionProviders: providers,
-			activeRunners: (await localState.snapshot()).claims.length,
+			adapters,
+			lanes: loaded.manifest.lanes,
+			capacity: loaded.manifest.capacity,
+			activeWorkers: (await localState.snapshot()).claims.length,
 		}, localState);
 	}));
 	return { ok: results.every((entry) => entry.ok !== false), role: 'manager', connections: results };
@@ -110,20 +115,10 @@ export async function runMultiTeamProviderRunners(
 	const localState = new ProviderLocalCapacityStore(config.dataDir);
 	const results: Record<string, unknown>[] = [];
 	for (const connection of connections) {
-		const runtime = context(config, connection, loaded.manifest.executionProviders, loaded.manifest.defaultExecutionProviderId);
-		const executionProviderId = loaded.manifest.defaultExecutionProviderId ?? loaded.manifest.executionProviders[0]?.id;
-		if (!executionProviderId) {
-			results.push({ connectionId: connection.connection.id, status: 'idle', reason: 'no_execution_provider' });
-			continue;
-		}
-		const executor = await resolveAgentExecutor(config, executionProviderId);
-		if (!executor || !(await executor.observe()).available) {
-			results.push({ connectionId: connection.connection.id, status: 'idle', reason: 'executor_unavailable' });
-			continue;
-		}
+		const runtime = context(config, connection, loaded.manifest);
 		const claim = await localState.claim({
 			connectionId: connection.connection.id,
-			globalLimit: config.maxConcurrentRunners,
+			globalLimit: loaded.manifest.capacity.maxConcurrentWorkers,
 			connectionLimit: connection.connection.offer.maxConcurrentRunners ?? config.maxConcurrentRunners,
 		});
 		if (!claim) {
@@ -145,6 +140,12 @@ export async function runMultiTeamProviderRunners(
 				results.push({ connectionId: connection.connection.id, status: 'idle', reason: 'no_assignment' });
 				continue;
 			}
+			const executionProviderId = text(assignment.executionProviderId, record(assignment.capacityEnvelope).executionProviderId);
+			const laneId = text(assignment.laneId, record(assignment.capacityEnvelope).laneId);
+			const adapter = loaded.manifest.adapters.find((candidate) => candidate.id === executionProviderId && (!laneId || candidate.laneIds.includes(laneId)));
+			if (!adapter) { await localState.release(claim.id); results.push({ connectionId: connection.connection.id, status: 'idle', reason: 'assignment_adapter_unavailable' }); continue; }
+			const executor = await resolveAgentExecutor(config, adapter);
+			if (!executor || !(await executor.observe()).available) { await localState.release(claim.id); results.push({ connectionId: connection.connection.id, status: 'idle', reason: 'executor_unavailable' }); continue; }
 			const leaseExpiresAt = text(assignment.leaseExpiresAt) ?? new Date(Date.now() + 300_000).toISOString();
 			await localState.attachLease(claim.id, {
 				assignmentId,

--- a/src/provider/teams/multi-team-runtime.ts
+++ b/src/provider/teams/multi-team-runtime.ts
@@ -78,7 +78,7 @@ export async function runMultiTeamProviderManager(
 		}
 		const runtime = context(config, connection.runtime, loaded.manifest);
 		const adapters = await Promise.all(loaded.manifest.adapters.map(async (adapter) => {
-			const executor = await resolveAgentExecutor(config, adapter).catch(() => null);
+			const executor = await resolveAgentExecutor(config, adapter, loaded.manifest).catch(() => null);
 			const observation = executor
 				? await executor.observe().catch((error) => ({ available: false, reason: error instanceof Error ? error.message : String(error) }))
 				: { available: false, reason: 'executor_not_configured' };
@@ -144,7 +144,7 @@ export async function runMultiTeamProviderRunners(
 			const laneId = text(assignment.laneId, record(assignment.capacityEnvelope).laneId);
 			const adapter = loaded.manifest.adapters.find((candidate) => candidate.id === executionProviderId && (!laneId || candidate.laneIds.includes(laneId)));
 			if (!adapter) { await localState.release(claim.id); results.push({ connectionId: connection.connection.id, status: 'idle', reason: 'assignment_adapter_unavailable' }); continue; }
-			const executor = await resolveAgentExecutor(config, adapter);
+			const executor = await resolveAgentExecutor(config, adapter, loaded.manifest);
 			if (!executor || !(await executor.observe()).available) { await localState.release(claim.id); results.push({ connectionId: connection.connection.id, status: 'idle', reason: 'executor_unavailable' }); continue; }
 			const leaseExpiresAt = text(assignment.leaseExpiresAt) ?? new Date(Date.now() + 300_000).toISOString();
 			await localState.attachLease(claim.id, {

--- a/tests/fixtures/process-executor-module.ts
+++ b/tests/fixtures/process-executor-module.ts
@@ -1,0 +1,12 @@
+import type { AgentExecutorModule } from '../../src/provider/execution/contracts.ts';
+
+export const createAgentExecutor: AgentExecutorModule['createAgentExecutor'] = ({ executionProviderId }) => ({
+	id: executionProviderId,
+	async observe() {
+		return { available: true, reason: JSON.stringify({ allowed: process.env.TREESEED_TEST_ALLOWED ?? null, forbidden: process.env.TREESEED_TEST_FORBIDDEN ?? null }) };
+	},
+	async execute(request) {
+		const result = await request.treeDx.invoke('treedx.health', { assignmentId: request.assignmentId });
+		return { status: 'completed', summary: 'isolated', outputs: { result } };
+	},
+});

--- a/tests/modern/process-executor.test.ts
+++ b/tests/modern/process-executor.test.ts
@@ -1,6 +1,6 @@
 import assert from 'node:assert/strict';
 import { resolve } from 'node:path';
-import test from 'node:test';
+import { test } from 'vitest';
 import type { CapacityProviderManifestV3 } from '@treeseed/sdk/capacity-provider';
 import { createProcessIsolatedExecutor } from '../../src/provider/execution/process-executor.ts';
 

--- a/tests/modern/process-executor.test.ts
+++ b/tests/modern/process-executor.test.ts
@@ -1,0 +1,23 @@
+import assert from 'node:assert/strict';
+import { resolve } from 'node:path';
+import test from 'node:test';
+import type { CapacityProviderManifestV3 } from '@treeseed/sdk/capacity-provider';
+import { createProcessIsolatedExecutor } from '../../src/provider/execution/process-executor.ts';
+
+test('process adapter receives only projected credentials and brokers TreeDX through the parent', async () => {
+	process.env.TREESEED_TEST_ALLOWED = 'allowed-value';
+	process.env.TREESEED_TEST_FORBIDDEN = 'forbidden-value';
+	const adapter: CapacityProviderManifestV3['adapters'][number] = { id: 'platform', adapter: 'fixture', isolation: 'process', credentialProfiles: ['allowed'], laneIds: ['platform'], maxConcurrentWorkers: 1, nativeLimits: {} };
+	const manifest = { schemaVersion: 3, ownership: { type: 'team', teamId: 'team' }, configuration: { generation: 'test' }, identity: { privateKeyRef: 'data://identity.json', displayName: 'test' }, capacity: { maxConcurrentWorkers: 1 }, credentialProfiles: [{ id: 'allowed', source: 'process-environment', reference: 'TREESEED_TEST_ALLOWED', required: true }], lanes: [{ id: 'communication', purpose: 'communication', priority: 100, reservedConcurrentWorkers: 1, maxConcurrentWorkers: 1, borrowWhenIdle: true, lendWhenIdle: true, reclaimPolicy: 'admission', queueLimit: 1, timeoutSeconds: 10 }, { id: 'platform', purpose: 'platform', priority: 70, reservedConcurrentWorkers: 0, maxConcurrentWorkers: 1, borrowWhenIdle: true, lendWhenIdle: true, reclaimPolicy: 'admission', queueLimit: 1, timeoutSeconds: 10 }, { id: 'workday', purpose: 'workday', priority: 50, reservedConcurrentWorkers: 0, maxConcurrentWorkers: 1, borrowWhenIdle: true, lendWhenIdle: true, reclaimPolicy: 'admission', queueLimit: 1, timeoutSeconds: 10 }], adapters: [adapter], connections: [] } satisfies CapacityProviderManifestV3;
+	const executor = createProcessIsolatedExecutor({ environment: 'test' } as any, manifest, adapter, resolve('tests/fixtures/process-executor-module.ts')) as ReturnType<typeof createProcessIsolatedExecutor> & { shutdown(): void };
+	try {
+		const observation = await executor.observe();
+		assert.deepEqual(JSON.parse(observation.reason!), { allowed: 'allowed-value', forbidden: null });
+		const result = await executor.execute({ assignment: {}, assignmentId: 'assignment-1', leaseToken: 'lease', runnerId: 'runner', treeDx: { projectId: 'project', repositoryId: null, workspaceId: null, invoke: async (operationId, input) => ({ operationId, input }) } });
+		assert.deepEqual(result.outputs, { result: { operationId: 'treedx.health', input: { assignmentId: 'assignment-1' } } });
+	} finally {
+		executor.shutdown();
+		delete process.env.TREESEED_TEST_ALLOWED;
+		delete process.env.TREESEED_TEST_FORBIDDEN;
+	}
+});

--- a/tests/modern/provider-boundary.test.ts
+++ b/tests/modern/provider-boundary.test.ts
@@ -24,7 +24,7 @@ describe('Agent package ownership boundary', () => {
 	it('fails closed when no trusted executor module is configured', async () => {
 		const config = resolveProviderConfig({ env: { TREESEED_PROVIDER_DATA_DIR: '/tmp/provider' } });
 		expect(config.executorModule).toBeNull();
-		await expect(resolveAgentExecutor(config, 'codex')).resolves.toBeNull();
+		await expect(resolveAgentExecutor(config, { id: 'codex', adapter: 'codex', isolation: 'worker', laneIds: ['workday'], maxConcurrentWorkers: 1, nativeLimits: {} })).resolves.toBeNull();
 	});
 
 	it('contains no raw control-plane paths or removed Market/API runtime terms', () => {


### PR DESCRIPTION
Closes #17. Implements one capacity-provider v3 runtime with communication, platform, and workday lanes under one shared budget; exact adapter/lane assignment selection; protected stdin enrollment handoff; and real child-process isolation with credential allowlisting and parent-brokered TreeDX access. Focused provider boundary, runner, enrollment, process isolation, build, and architecture checks pass. No live assignment or workday is started.