### PR TITLE
Use fresh provider identity and local connection custody

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,15 +1,15 @@
 {
   "name": "@treeseed/agent",
-  "version": "0.13.0-rc.5",
+  "version": "0.13.0-rc.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@treeseed/agent",
-      "version": "0.13.0-rc.5",
+      "version": "0.13.0-rc.6",
       "license": "Apache-2.0",
       "dependencies": {
-        "@treeseed/sdk": "0.13.0-rc.20",
+        "@treeseed/sdk": "0.13.0-rc.23",
         "esbuild": "0.28.2",
         "typescript": "^5.9.3",
         "yaml": "^2.8.1"
@@ -727,12 +727,12 @@
       "license": "MIT"
     },
     "node_modules/@treeseed/sdk": {
-      "version": "0.13.0-rc.20",
-      "resolved": "https://registry.npmjs.org/@treeseed/sdk/-/sdk-0.13.0-rc.20.tgz",
-      "integrity": "sha512-XM2ewAUACIO/umqZEsKlfdJxaDZW8IyMnH5pSoS7vcySKbMb/2bGPwJpfIIuNui9vMAkQ7KwkoIEV5fHXiFUvQ==",
+      "version": "0.13.0-rc.23",
+      "resolved": "https://registry.npmjs.org/@treeseed/sdk/-/sdk-0.13.0-rc.23.tgz",
+      "integrity": "sha512-OKswjhRcoPLkYiZ6pONDlSXqhsDkNJVDkRPwgCBaJvaPwdIFGWPBGfVDuADYR4gyJK7CgjbON1mQwntrAowYHg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@treeseed/treedx": "0.3.0-rc.3",
+        "@treeseed/treedx": "0.3.0-rc.4",
         "esbuild": "^0.28.0",
         "typescript": "^5.9.3",
         "yaml": "^2.8.1",
@@ -752,9 +752,9 @@
       }
     },
     "node_modules/@treeseed/treedx": {
-      "version": "0.3.0-rc.3",
-      "resolved": "https://registry.npmjs.org/@treeseed/treedx/-/treedx-0.3.0-rc.3.tgz",
-      "integrity": "sha512-JAp4BywPn0VaFXs+BFnbRj2SGkUmJ7OrS+3mjtCKUVVY7aLJTHgcsnva2G8pCTuY1mjcDSdM3HKWtixiIYt+IA==",
+      "version": "0.3.0-rc.4",
+      "resolved": "https://registry.npmjs.org/@treeseed/treedx/-/treedx-0.3.0-rc.4.tgz",
+      "integrity": "sha512-ZBmY/C30kge84Ns/qzpa/h4XfLXtZMDiyfCJM8WTLHQBU2I5QYrhx2aI32mHk90jQib+SyWfwYMknIip8RHF8A==",
       "license": "Apache-2.0",
       "engines": {
         "node": ">=22"

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.13.0-rc.6",
       "license": "Apache-2.0",
       "dependencies": {
-        "@treeseed/sdk": "0.13.0-rc.23",
+        "@treeseed/sdk": "0.13.0-rc.24",
         "esbuild": "0.28.2",
         "typescript": "^5.9.3",
         "yaml": "^2.8.1"
@@ -727,9 +727,9 @@
       "license": "MIT"
     },
     "node_modules/@treeseed/sdk": {
-      "version": "0.13.0-rc.23",
-      "resolved": "https://registry.npmjs.org/@treeseed/sdk/-/sdk-0.13.0-rc.23.tgz",
-      "integrity": "sha512-OKswjhRcoPLkYiZ6pONDlSXqhsDkNJVDkRPwgCBaJvaPwdIFGWPBGfVDuADYR4gyJK7CgjbON1mQwntrAowYHg==",
+      "version": "0.13.0-rc.24",
+      "resolved": "https://registry.npmjs.org/@treeseed/sdk/-/sdk-0.13.0-rc.24.tgz",
+      "integrity": "sha512-ocYAG2EOzxsNMc5Ix/tqMwAlX1THxfISTyT7Tit1F7ORpn1+4HXRXXQg1OM1jE33nMKMPrk0sfDts4cycx+zaw==",
       "license": "Apache-2.0",
       "dependencies": {
         "@treeseed/treedx": "0.3.0-rc.4",

--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
     "test:provider-runtime": "npm run test:modern"
   },
   "dependencies": {
-    "@treeseed/sdk": "0.13.0-rc.23",
+    "@treeseed/sdk": "0.13.0-rc.24",
     "esbuild": "0.28.2",
     "typescript": "^5.9.3",
     "yaml": "^2.8.1"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@treeseed/agent",
-  "version": "0.13.0-rc.5",
+  "version": "0.13.0-rc.6",
   "description": "Treeseed agent service runtime package.",
   "license": "Apache-2.0",
   "repository": {
@@ -62,7 +62,7 @@
     "test:provider-runtime": "npm run test:modern"
   },
   "dependencies": {
-    "@treeseed/sdk": "0.13.0-rc.20",
+    "@treeseed/sdk": "0.13.0-rc.23",
     "esbuild": "0.28.2",
     "typescript": "^5.9.3",
     "yaml": "^2.8.1"

--- a/src/provider-governance.ts
+++ b/src/provider-governance.ts
@@ -5,12 +5,13 @@ export {
 } from './provider/coordination/coordinator.ts';
 export {
 	initializeCapacityProviderIdentity,
+	ensureCapacityProviderIdentity,
 	loadCapacityProviderIdentity,
 } from './provider/accounts/identity.ts';
 export {
 	DEFAULT_PROVIDER_MANIFEST,
 	loadProviderManifest,
-	writeProviderManifest,
+	writeProviderConnections,
 	providerSecretPath,
 	providerConnectionControlPlaneUrl,
 	providerConnectionControlPlaneAudience,

--- a/src/provider/accounts/identity.ts
+++ b/src/provider/accounts/identity.ts
@@ -46,6 +46,22 @@ export async function initializeCapacityProviderIdentity(input: { ref: string; b
 	return privateJwk;
 }
 
+export async function ensureCapacityProviderIdentity(input: {
+	ref: string;
+	baseDirectory: string;
+	dataDirectory?: string;
+	env?: NodeJS.ProcessEnv;
+	resolver?: ProviderSecretResolver;
+}) {
+	try {
+		return await loadCapacityProviderIdentity(input);
+	} catch (error) {
+		if ((error as NodeJS.ErrnoException).code !== 'ENOENT') throw error;
+		await initializeCapacityProviderIdentity(input);
+		return loadCapacityProviderIdentity(input);
+	}
+}
+
 export async function loadCapacityProviderIdentity(input: {
 	ref: string;
 	baseDirectory: string;

--- a/src/provider/configuration/manifest.ts
+++ b/src/provider/configuration/manifest.ts
@@ -13,6 +13,7 @@ export const DEFAULT_PROVIDER_MANIFEST = 'treeseed.capacity-provider.yaml';
 export interface LoadedProviderManifest {
 	path: string;
 	directory: string;
+	dataDirectory?: string;
 	manifest: CapacityProviderManifestV3;
 }
 
@@ -24,22 +25,42 @@ function diagnosticMessage(diagnostics: Array<{ path: string; message: string }>
 	return diagnostics.map((entry) => `${entry.path}: ${entry.message}`).join('; ');
 }
 
-export async function loadProviderManifest(path = process.env.TREESEED_CAPACITY_PROVIDER_MANIFEST || DEFAULT_PROVIDER_MANIFEST): Promise<LoadedProviderManifest> {
-	const absolute = resolve(path);
-	const parsed = parseYaml(await readFile(absolute, 'utf8')) as CapacityProviderManifestV3;
-	const validation = validateCapacityProviderManifestV3(parsed);
-	if (!validation.ok) throw new Error(`Invalid capacity provider manifest: ${diagnosticMessage(validation.diagnostics)}`);
-	return { path: absolute, directory: dirname(absolute), manifest: parsed };
+const connectionOverlayPath = (dataDirectory: string) => resolve(dataDirectory, 'connections.yaml');
+
+async function localConnections(dataDirectory: string | undefined) {
+	if (!dataDirectory) return null;
+	try {
+		const value = parseYaml(await readFile(connectionOverlayPath(dataDirectory), 'utf8'));
+		if (!Array.isArray(value)) throw new Error('Provider connection overlay must contain an array.');
+		return value as ProviderConnectionConfig[];
+	} catch (error) {
+		if ((error as NodeJS.ErrnoException).code === 'ENOENT') return null;
+		throw error;
+	}
 }
 
-export async function writeProviderManifest(loaded: LoadedProviderManifest, manifest: CapacityProviderManifestV3) {
+export async function loadProviderManifest(path = process.env.TREESEED_CAPACITY_PROVIDER_MANIFEST || DEFAULT_PROVIDER_MANIFEST, dataDirectory?: string): Promise<LoadedProviderManifest> {
+	const absolute = resolve(path);
+	const parsed = parseYaml(await readFile(absolute, 'utf8')) as CapacityProviderManifestV3;
+	const overlay = await localConnections(dataDirectory);
+	const manifest = overlay ? { ...parsed, connections: overlay } : parsed;
 	const validation = validateCapacityProviderManifestV3(manifest);
 	if (!validation.ok) throw new Error(`Invalid capacity provider manifest: ${diagnosticMessage(validation.diagnostics)}`);
-	const temporary = `${loaded.path}.${process.pid}.${Date.now()}.tmp`;
-	await writeFile(temporary, stringifyYaml(manifest), { encoding: 'utf8', mode: 0o600, flag: 'wx' });
+	return { path: absolute, directory: dirname(absolute), ...(dataDirectory ? { dataDirectory } : {}), manifest };
+}
+
+export async function writeProviderConnections(loaded: LoadedProviderManifest, connections: ProviderConnectionConfig[]) {
+	if (!loaded.dataDirectory) throw new Error('Provider connection updates require a local data directory.');
+	const manifest = { ...loaded.manifest, connections };
+	const validation = validateCapacityProviderManifestV3(manifest);
+	if (!validation.ok) throw new Error(`Invalid capacity provider manifest: ${diagnosticMessage(validation.diagnostics)}`);
+	const path = connectionOverlayPath(loaded.dataDirectory);
+	await mkdir(dirname(path), { recursive: true, mode: 0o700 });
+	const temporary = `${path}.${process.pid}.${Date.now()}.tmp`;
+	await writeFile(temporary, stringifyYaml(connections), { encoding: 'utf8', mode: 0o600, flag: 'wx' });
 	await chmod(temporary, 0o600);
-	await rename(temporary, loaded.path);
-	await chmod(loaded.path, 0o600);
+	await rename(temporary, path);
+	await chmod(path, 0o600);
 	loaded.manifest = manifest;
 	return loaded;
 }

--- a/src/provider/coordination/coordinator.ts
+++ b/src/provider/coordination/coordinator.ts
@@ -24,7 +24,7 @@ import {
 	removeProviderSecret,
 	resolveProviderSecret,
 	stageProviderSecret,
-	writeProviderManifest,
+	writeProviderConnections,
 	writeProviderSecret,
 	type LoadedProviderManifest,
 	type ProviderSecretResolver,
@@ -194,7 +194,7 @@ export class CapacityProviderCoordinator {
 		const mutation = this.manifestMutation.then(async () => {
 			const connections = [...this.loaded.manifest.connections.filter((entry) => entry.id !== connection.id), connection]
 				.sort((left, right) => left.id.localeCompare(right.id));
-			await writeProviderManifest(this.loaded, { ...this.loaded.manifest, connections });
+			await writeProviderConnections(this.loaded, connections);
 		});
 		this.manifestMutation = mutation.catch(() => undefined);
 		await mutation;
@@ -295,7 +295,7 @@ export class CapacityProviderCoordinator {
 			remoteError = error instanceof Error ? error.message : String(error);
 		}
 		const connections = this.loaded.manifest.connections.filter((entry) => entry.id !== connectionId);
-		await writeProviderManifest(this.loaded, { ...this.loaded.manifest, connections });
+		await writeProviderConnections(this.loaded, connections);
 		await removeProviderConnectionState(this.dataDir, connectionId);
 		if (state?.generatedCredentialRef) await removeProviderSecret(state.generatedCredentialRef, this.loaded.directory, this.dataDir);
 		await this.localState.removeToken(connectionId);

--- a/src/provider/lifecycle/entrypoint.ts
+++ b/src/provider/lifecycle/entrypoint.ts
@@ -159,6 +159,11 @@ async function main() {
 		const teamId = String(input.teamId ?? '');
 		const loaded = await import('../configuration/manifest.ts').then(({ loadProviderManifest }) => loadProviderManifest(config.manifestPath!));
 		if (!enrollmentToken || !teamId) throw new Error('Provider enrollment requires a team and one-time token.');
+		await import('../accounts/identity.ts').then(({ ensureCapacityProviderIdentity }) => ensureCapacityProviderIdentity({
+			ref: loaded.manifest.identity.privateKeyRef,
+			baseDirectory: loaded.directory,
+			dataDirectory: config.dataDir,
+		}));
 		const receipt = await coordinator.beginJoin({ id: connectionId,
 			...(input.serverProfile ? { serverProfile: String(input.serverProfile) } : { controlPlaneUrl: String(input.controlPlaneUrl ?? '') }),
 			controlPlaneAudience: String(input.controlPlaneAudience ?? input.controlPlaneUrl ?? ''), registrationKeyRef: 'memory://one-time',

--- a/src/provider/lifecycle/entrypoint.ts
+++ b/src/provider/lifecycle/entrypoint.ts
@@ -157,7 +157,7 @@ async function main() {
 		}
 		const enrollmentToken = String(input.enrollmentToken ?? '');
 		const teamId = String(input.teamId ?? '');
-		const loaded = await import('../configuration/manifest.ts').then(({ loadProviderManifest }) => loadProviderManifest(config.manifestPath!));
+		const loaded = await import('../configuration/manifest.ts').then(({ loadProviderManifest }) => loadProviderManifest(config.manifestPath!, config.dataDir));
 		if (!enrollmentToken || !teamId) throw new Error('Provider enrollment requires a team and one-time token.');
 		await import('../accounts/identity.ts').then(({ ensureCapacityProviderIdentity }) => ensureCapacityProviderIdentity({
 			ref: loaded.manifest.identity.privateKeyRef,

--- a/src/provider/lifecycle/lifecycle.ts
+++ b/src/provider/lifecycle/lifecycle.ts
@@ -4,6 +4,7 @@ import type { ProviderSupplyOffer } from '@treeseed/sdk/capacity-provider/contra
 import type { ProviderConnectionRuntimeContext, ProviderHostRuntimeConfig } from '../configuration/config.ts';
 import { discoverProviderBudgets } from '../configuration/budgets.ts';
 import { discoverProviderCapabilities } from '../configuration/capabilities.ts';
+import { loadProviderManifest } from '../configuration/manifest.ts';
 import { createProviderControlPlaneClient } from '../coordination/client.ts';
 import { ProviderLocalCapacityStore } from '../capacity/capacity-core/local-capacity-store.ts';
 import { observeProviderDiskCapacity } from '../runtime/disk-capacity.ts';
@@ -27,11 +28,22 @@ export async function checkProviderHealth(config: ProviderHostRuntimeConfig) {
 }
 
 export async function buildProviderPlan(config: ProviderHostRuntimeConfig) {
+	const manifest = config.manifestPath
+		? (await loadProviderManifest(config.manifestPath, config.dataDir)).manifest
+		: null;
+	const capabilities = manifest
+		? [...new Set([
+			...manifest.adapters.flatMap((adapter) => adapter.capabilities ?? []),
+			...manifest.lanes.flatMap((lane) => lane.capabilities ?? []),
+		])].sort()
+		: discoverProviderCapabilities(config).map((capability) => capability.id);
 	return okPayload('plan', {
 		mode: 'plan',
 		dataDir: config.dataDir,
-		capabilities: discoverProviderCapabilities(config).map((capability) => capability.id),
-		budgets: discoverProviderBudgets(config),
+		capabilities,
+		capacity: manifest?.capacity ?? discoverProviderBudgets(config),
+		lanes: manifest?.lanes ?? [],
+		adapters: manifest?.adapters ?? [],
 		executorConfigured: Boolean(config.executorModule),
 		redactedEnv: config.redactedEnv,
 	});

--- a/src/provider/teams/multi-team-runtime.ts
+++ b/src/provider/teams/multi-team-runtime.ts
@@ -40,7 +40,7 @@ function context(
 
 export async function createCapacityProviderCoordinator(config: ProviderHostRuntimeConfig) {
 	if (!config.manifestPath) throw new Error('A capacity provider manifest is required.');
-	return new CapacityProviderCoordinator(await loadProviderManifest(config.manifestPath), config.dataDir);
+	return new CapacityProviderCoordinator(await loadProviderManifest(config.manifestPath, config.dataDir), config.dataDir);
 }
 
 export async function reconcileProviderConnections(config: ProviderHostRuntimeConfig) {
@@ -56,7 +56,7 @@ export async function runMultiTeamProviderManager(
 	config: ProviderHostRuntimeConfig,
 	options: { mode?: 'plan' | 'live' } = {},
 ) {
-	const loaded = await loadProviderManifest(config.manifestPath ?? '');
+	const loaded = await loadProviderManifest(config.manifestPath ?? '', config.dataDir);
 	if (options.mode === 'plan') {
 		return {
 			ok: true,
@@ -110,7 +110,7 @@ export async function runMultiTeamProviderRunners(
 	options: { mode?: 'plan' | 'live'; background?: boolean } = {},
 ) {
 	if (options.mode === 'plan') return buildProviderRunnerPlan(config);
-	const loaded = await loadProviderManifest(config.manifestPath ?? '');
+	const loaded = await loadProviderManifest(config.manifestPath ?? '', config.dataDir);
 	const connections = (await reconcileProviderConnections(config)).flatMap((entry) => entry.runtime ? [entry.runtime] : []);
 	const localState = new ProviderLocalCapacityStore(config.dataDir);
 	const results: Record<string, unknown>[] = [];

--- a/tests/modern/provider-boundary.test.ts
+++ b/tests/modern/provider-boundary.test.ts
@@ -8,6 +8,7 @@ import { resolveAgentExecutor } from '../../src/provider/execution/executor-load
 import { resolveProviderConfig } from '../../src/provider/configuration/config.ts';
 import { ensureCapacityProviderIdentity } from '../../src/provider/accounts/identity.ts';
 import { loadProviderManifest, writeProviderConnections } from '../../src/provider/configuration/manifest.ts';
+import { buildProviderPlan } from '../../src/provider/lifecycle/lifecycle.ts';
 import { stringify as stringifyYaml } from 'yaml';
 
 function sourceFiles(root: string): string[] {
@@ -67,6 +68,14 @@ describe('Agent package ownership boundary', () => {
 		const canonical = readFileSync(manifestPath, 'utf8');
 		try {
 			const loaded = await loadProviderManifest(manifestPath, dataDirectory);
+			const plan = await buildProviderPlan(resolveProviderConfig({ env: {
+				TREESEED_CAPACITY_PROVIDER_MANIFEST: manifestPath,
+				TREESEED_PROVIDER_DATA_DIR: dataDirectory,
+			} })) as { lanes: Array<{ purpose: string }>; adapters: Array<{ id: string }>; capacity: { maxConcurrentWorkers: number }; capabilities: string[] };
+			expect(plan.lanes.map((lane) => lane.purpose)).toEqual(['communication', 'platform', 'workday']);
+			expect(plan.adapters.map((adapter) => adapter.id)).toEqual(['test']);
+			expect(plan.capacity.maxConcurrentWorkers).toBe(1);
+			expect(plan.capabilities).toEqual(['communication']);
 			await writeProviderConnections(loaded, [{ id: 'local', controlPlaneUrl: 'http://127.0.0.1:3002', controlPlaneAudience: 'http://127.0.0.1:3002',
 				teamId: 'team-1', providerId: 'provider-1', membershipId: 'membership-1', membershipCredentialRef: 'data://credential',
 				membershipCredentialId: 'credential-1', offer: { maxConcurrentRunners: 1, capabilities: ['communication'] } }]);

--- a/tests/modern/provider-boundary.test.ts
+++ b/tests/modern/provider-boundary.test.ts
@@ -1,10 +1,12 @@
-import { readFileSync, readdirSync } from 'node:fs';
+import { mkdtempSync, readFileSync, readdirSync, rmSync, statSync } from 'node:fs';
+import { tmpdir } from 'node:os';
 import { resolve } from 'node:path';
 import { describe, expect, it } from 'vitest';
 import { CONTROL_PLANE_OPERATIONS } from '@treeseed/sdk/operator-contracts';
 import { providerOperationPath } from '../../src/provider/coordination/client.ts';
 import { resolveAgentExecutor } from '../../src/provider/execution/executor-loader.ts';
 import { resolveProviderConfig } from '../../src/provider/configuration/config.ts';
+import { ensureCapacityProviderIdentity } from '../../src/provider/accounts/identity.ts';
 
 function sourceFiles(root: string): string[] {
 	return readdirSync(root, { withFileTypes: true }).flatMap((entry) => {
@@ -25,6 +27,22 @@ describe('Agent package ownership boundary', () => {
 		const config = resolveProviderConfig({ env: { TREESEED_PROVIDER_DATA_DIR: '/tmp/provider' } });
 		expect(config.executorModule).toBeNull();
 		await expect(resolveAgentExecutor(config, { id: 'codex', adapter: 'codex', isolation: 'worker', laneIds: ['workday'], maxConcurrentWorkers: 1, nativeLimits: {} })).resolves.toBeNull();
+	});
+
+	it('creates one fresh private identity in local enrollment custody and reuses it on retry', async () => {
+		const dataDirectory = mkdtempSync(resolve(tmpdir(), 'treeseed-provider-identity-'));
+		try {
+			const input = { ref: 'data://identity-v3.json', baseDirectory: dataDirectory, dataDirectory };
+			const first = await ensureCapacityProviderIdentity(input);
+			const second = await ensureCapacityProviderIdentity(input);
+			expect(second.publicJwk).toEqual(first.publicJwk);
+			expect(statSync(resolve(dataDirectory, 'identity-v3.json')).mode & 0o777).toBe(0o600);
+			const stored = JSON.parse(readFileSync(resolve(dataDirectory, 'identity-v3.json'), 'utf8')) as { d?: string; x?: string };
+			expect(stored.x).toBe(first.publicJwk.x);
+			expect(typeof stored.d).toBe('string');
+		} finally {
+			rmSync(dataDirectory, { recursive: true, force: true });
+		}
 	});
 
 	it('contains no raw control-plane paths or removed Market/API runtime terms', () => {

--- a/tests/modern/provider-boundary.test.ts
+++ b/tests/modern/provider-boundary.test.ts
@@ -1,4 +1,4 @@
-import { mkdtempSync, readFileSync, readdirSync, rmSync, statSync } from 'node:fs';
+import { mkdtempSync, readFileSync, readdirSync, rmSync, statSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { resolve } from 'node:path';
 import { describe, expect, it } from 'vitest';
@@ -7,6 +7,8 @@ import { providerOperationPath } from '../../src/provider/coordination/client.ts
 import { resolveAgentExecutor } from '../../src/provider/execution/executor-loader.ts';
 import { resolveProviderConfig } from '../../src/provider/configuration/config.ts';
 import { ensureCapacityProviderIdentity } from '../../src/provider/accounts/identity.ts';
+import { loadProviderManifest, writeProviderConnections } from '../../src/provider/configuration/manifest.ts';
+import { stringify as stringifyYaml } from 'yaml';
 
 function sourceFiles(root: string): string[] {
 	return readdirSync(root, { withFileTypes: true }).flatMap((entry) => {
@@ -42,6 +44,37 @@ describe('Agent package ownership boundary', () => {
 			expect(typeof stored.d).toBe('string');
 		} finally {
 			rmSync(dataDirectory, { recursive: true, force: true });
+		}
+	});
+
+	it('stores mutable connections in local custody without rewriting the canonical manifest', async () => {
+		const root = mkdtempSync(resolve(tmpdir(), 'treeseed-provider-connections-'));
+		const dataDirectory = resolve(root, 'data');
+		const manifestPath = resolve(root, 'treeseed.capacity-provider.yaml');
+		const manifest = {
+			schemaVersion: 3, ownership: { type: 'team', teamId: 'team-1' }, configuration: { generation: 'test' },
+			identity: { privateKeyRef: 'data://identity-v3.json', displayName: 'Test' },
+			capacity: { maxConcurrentWorkers: 1 }, credentialProfiles: [],
+			lanes: [
+				{ id: 'communication', purpose: 'communication', priority: 100, reservedConcurrentWorkers: 1, maxConcurrentWorkers: 1, borrowWhenIdle: true, lendWhenIdle: true, reclaimPolicy: 'admission', queueLimit: 1, timeoutSeconds: 30 },
+				{ id: 'platform', purpose: 'platform', priority: 70, reservedConcurrentWorkers: 0, maxConcurrentWorkers: 1, borrowWhenIdle: true, lendWhenIdle: true, reclaimPolicy: 'admission', queueLimit: 1, timeoutSeconds: 30 },
+				{ id: 'workday', purpose: 'workday', priority: 50, reservedConcurrentWorkers: 0, maxConcurrentWorkers: 1, borrowWhenIdle: true, lendWhenIdle: true, reclaimPolicy: 'admission', queueLimit: 1, timeoutSeconds: 30 },
+			],
+			adapters: [{ id: 'test', adapter: 'codex', isolation: 'process', laneIds: ['communication', 'workday'], maxConcurrentWorkers: 1, nativeLimits: {}, capabilities: ['communication'] }],
+			connections: [],
+		};
+		writeFileSync(manifestPath, stringifyYaml(manifest));
+		const canonical = readFileSync(manifestPath, 'utf8');
+		try {
+			const loaded = await loadProviderManifest(manifestPath, dataDirectory);
+			await writeProviderConnections(loaded, [{ id: 'local', controlPlaneUrl: 'http://127.0.0.1:3002', controlPlaneAudience: 'http://127.0.0.1:3002',
+				teamId: 'team-1', providerId: 'provider-1', membershipId: 'membership-1', membershipCredentialRef: 'data://credential',
+				membershipCredentialId: 'credential-1', offer: { maxConcurrentRunners: 1, capabilities: ['communication'] } }]);
+			expect(readFileSync(manifestPath, 'utf8')).toBe(canonical);
+			expect(statSync(resolve(dataDirectory, 'connections.yaml')).mode & 0o777).toBe(0o600);
+			expect((await loadProviderManifest(manifestPath, dataDirectory)).manifest.connections).toHaveLength(1);
+		} finally {
+			rmSync(root, { recursive: true, force: true });
 		}
 	});
 


### PR DESCRIPTION
Closes #19\n\n## Summary\n- pin exact \n- create a fresh Ed25519 provider identity during enrollment\n- store mutable provider connections only in protected local custody\n- keep the repository provider manifest immutable\n- publish availability through catalog-driven idempotent operations\n\n## Verification\n- focused provider-boundary tests passed\n- Agent build passed\n- local manager published a fresh availability session\n- no runner, live assignment, workday, repository mutation, or TreeDX mutation started