### PR TITLE
Publish truthful provider capability identifiers

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@treeseed/agent",
-  "version": "0.13.0-rc.6",
+  "version": "0.13.0-rc.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@treeseed/agent",
-      "version": "0.13.0-rc.6",
+      "version": "0.13.0-rc.7",
       "license": "Apache-2.0",
       "dependencies": {
         "@treeseed/sdk": "0.13.0-rc.24",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@treeseed/agent",
-  "version": "0.13.0-rc.6",
+  "version": "0.13.0-rc.7",
   "description": "Treeseed agent service runtime package.",
   "license": "Apache-2.0",
   "repository": {

--- a/src/provider/lifecycle/lifecycle.ts
+++ b/src/provider/lifecycle/lifecycle.ts
@@ -58,6 +58,13 @@ export interface ProviderAvailabilityProjection {
 	constraints?: Record<string, unknown>;
 }
 
+export function providerAvailabilityCapabilities(availability: ProviderAvailabilityProjection) {
+	return [...new Set([
+		...availability.adapters.flatMap((adapter) => Array.isArray(adapter.capabilities) ? adapter.capabilities.filter((value): value is string => typeof value === 'string') : []),
+		...availability.lanes.flatMap((lane) => Array.isArray(lane.capabilities) ? lane.capabilities.filter((value): value is string => typeof value === 'string') : []),
+	])].sort();
+}
+
 export async function publishProviderAvailability(
 	config: ProviderConnectionRuntimeContext,
 	availability: ProviderAvailabilityProjection,
@@ -72,7 +79,7 @@ export async function publishProviderAvailability(
 		adapters: availability.adapters,
 		lanes: availability.lanes,
 		capacity: availability.capacity,
-		capabilities: discoverProviderCapabilities(config),
+		capabilities: providerAvailabilityCapabilities(availability),
 		runnerPressure: { activeWorkers: availability.activeWorkers ?? 0,
 			maxConcurrentWorkers: Number(availability.capacity.maxConcurrentWorkers ?? config.maxConcurrentRunners),
 			activeAssignmentIds: [] },

--- a/tests/modern/provider-boundary.test.ts
+++ b/tests/modern/provider-boundary.test.ts
@@ -8,7 +8,7 @@ import { resolveAgentExecutor } from '../../src/provider/execution/executor-load
 import { resolveProviderConfig } from '../../src/provider/configuration/config.ts';
 import { ensureCapacityProviderIdentity } from '../../src/provider/accounts/identity.ts';
 import { loadProviderManifest, writeProviderConnections } from '../../src/provider/configuration/manifest.ts';
-import { buildProviderPlan } from '../../src/provider/lifecycle/lifecycle.ts';
+import { buildProviderPlan, providerAvailabilityCapabilities } from '../../src/provider/lifecycle/lifecycle.ts';
 import { stringify as stringifyYaml } from 'yaml';
 
 function sourceFiles(root: string): string[] {
@@ -92,5 +92,13 @@ describe('Agent package ownership boundary', () => {
 		expect(source).not.toMatch(/\/v1\//u);
 		expect(source).not.toMatch(/MarketClient|marketId|marketUrl|marketAudience|TREESEED_MARKET/u);
 		expect(source).not.toMatch(/@treeseed\/sdk\/(?:sdk|platform|operations|copilot|git-runtime|frontmatter|content-operations|agent-tools)(?:['"]|\/)/u);
+	});
+
+	it('publishes capability identifiers rather than local capability objects', () => {
+		expect(providerAvailabilityCapabilities({
+			adapters: [{ capabilities: ['communication', 'acting'] }],
+			lanes: [{ capabilities: ['communication', 'planning'] }],
+			capacity: {},
+		})).toEqual(['acting', 'communication', 'planning']);
 	});
 });


### PR DESCRIPTION
Closes #21

## Summary
- publish only string capability identifiers in availability snapshots
- deduplicate adapter and lane capabilities deterministically
- advance the correction candidate to `0.13.0-rc.7`

## Verification
- focused provider-boundary tests: 6 passed
- Agent build passed
- no runner, assignment, workday, repository mutation, or TreeDX mutation started