### PR TITLE
Resolve portable executor module identifiers

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@treeseed/agent",
-  "version": "0.13.0-rc.8",
+  "version": "0.13.0-rc.9",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@treeseed/agent",
-      "version": "0.13.0-rc.8",
+      "version": "0.13.0-rc.9",
       "license": "Apache-2.0",
       "dependencies": {
         "@treeseed/sdk": "0.13.0-rc.25",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@treeseed/agent",
-  "version": "0.13.0-rc.8",
+  "version": "0.13.0-rc.9",
   "description": "Treeseed agent service runtime package.",
   "license": "Apache-2.0",
   "repository": {

--- a/src/provider/execution/contracts.ts
+++ b/src/provider/execution/contracts.ts
@@ -37,6 +37,7 @@ export interface AgentExecutor {
   observe(): Promise<AgentExecutorObservation>;
   execute(request: AgentExecutionRequest): Promise<AgentExecutionResult>;
   recover?(request: Pick<AgentExecutionRequest, 'assignment' | 'assignmentId' | 'runnerId'>): Promise<AgentExecutionResult | null>;
+  shutdown?(): void | Promise<void>;
 }
 
 export interface AgentExecutorModule {

--- a/src/provider/execution/executor-loader.ts
+++ b/src/provider/execution/executor-loader.ts
@@ -7,7 +7,18 @@ import { createProcessIsolatedExecutor } from './process-executor.ts';
 
 const cache = new Map<string, Promise<AgentExecutorModule>>();
 
+const EXECUTOR_MODULES: Readonly<Record<string, string>> = {
+  'module:codex-chat': '@treeseed/agent/executors/codex-chat',
+};
+
+export function executorModuleSpecifier(identifier: string) {
+  const specifier = EXECUTOR_MODULES[identifier] ?? (identifier.startsWith('builtin:') || identifier.startsWith('module:') ? null : identifier);
+  if (!specifier) throw new Error(`Unknown capacity provider executor module identifier ${identifier}.`);
+  return specifier;
+}
+
 async function loadModule(specifier: string) {
+  specifier = executorModuleSpecifier(specifier);
   const key = isAbsolute(specifier) || specifier.startsWith('.') ? pathToFileURL(resolve(specifier)).href : specifier;
   let loaded = cache.get(key);
   if (!loaded) {
@@ -22,9 +33,10 @@ async function loadModule(specifier: string) {
 export async function resolveAgentExecutor(config: ProviderHostRuntimeConfig, adapter: CapacityProviderManifestV3['adapters'][number], manifest: CapacityProviderManifestV3): Promise<AgentExecutor | null> {
   const module = adapter.module ?? config.executorModule;
   if (!module) return null;
-  if (adapter.isolation === 'process') return createProcessIsolatedExecutor(config, manifest, adapter, module);
+  const specifier = executorModuleSpecifier(module);
+  if (adapter.isolation === 'process') return createProcessIsolatedExecutor(config, manifest, adapter, specifier);
   if ((adapter.credentialProfiles?.length ?? 0) > 0) throw new Error(`Worker-isolated adapter ${adapter.id} may not receive credential profiles.`);
-  const executor = await (await loadModule(module)).createAgentExecutor({ executionProviderId: adapter.id, environment: config.environment });
+  const executor = await (await loadModule(specifier)).createAgentExecutor({ executionProviderId: adapter.id, environment: config.environment });
   if (!executor || typeof executor.execute !== 'function' || typeof executor.observe !== 'function') {
     throw new Error('Agent executor module returned an invalid executor.');
   }

--- a/src/provider/execution/process-executor.ts
+++ b/src/provider/execution/process-executor.ts
@@ -63,7 +63,7 @@ export function createProcessIsolatedExecutor(config: ProviderHostRuntimeConfig,
 		id: adapter.id,
 		observe: () => invoke<AgentExecutorObservation>('observe'),
 		execute: (request: AgentExecutionRequest) => invoke<AgentExecutionResult>('execute', request),
-		shutdown: () => child.kill('SIGTERM'),
+		shutdown: () => { child.kill('SIGTERM'); },
 	};
 	return proxy;
 }

--- a/src/provider/teams/multi-team-runtime.ts
+++ b/src/provider/teams/multi-team-runtime.ts
@@ -80,7 +80,9 @@ export async function runMultiTeamProviderManager(
 		const adapters = await Promise.all(loaded.manifest.adapters.map(async (adapter) => {
 			const executor = await resolveAgentExecutor(config, adapter, loaded.manifest).catch(() => null);
 			const observation = executor
-				? await executor.observe().catch((error) => ({ available: false, reason: error instanceof Error ? error.message : String(error) }))
+				? await executor.observe()
+					.catch((error) => ({ available: false, reason: error instanceof Error ? error.message : String(error) }))
+					.finally(() => executor.shutdown?.())
 				: { available: false, reason: 'executor_not_configured' };
 			return {
 				id: adapter.id,

--- a/tests/modern/provider-boundary.test.ts
+++ b/tests/modern/provider-boundary.test.ts
@@ -4,7 +4,7 @@ import { resolve } from 'node:path';
 import { describe, expect, it } from 'vitest';
 import { CONTROL_PLANE_OPERATIONS } from '@treeseed/sdk/operator-contracts';
 import { providerOperationPath } from '../../src/provider/coordination/client.ts';
-import { resolveAgentExecutor } from '../../src/provider/execution/executor-loader.ts';
+import { executorModuleSpecifier, resolveAgentExecutor } from '../../src/provider/execution/executor-loader.ts';
 import { resolveProviderConfig } from '../../src/provider/configuration/config.ts';
 import { ensureCapacityProviderIdentity } from '../../src/provider/accounts/identity.ts';
 import { loadProviderManifest, writeProviderConnections } from '../../src/provider/configuration/manifest.ts';
@@ -30,6 +30,11 @@ describe('Agent package ownership boundary', () => {
 		const config = resolveProviderConfig({ env: { TREESEED_PROVIDER_DATA_DIR: '/tmp/provider' } });
 		expect(config.executorModule).toBeNull();
 		await expect(resolveAgentExecutor(config, { id: 'codex', adapter: 'codex', isolation: 'worker', laneIds: ['workday'], maxConcurrentWorkers: 1, nativeLimits: {} })).resolves.toBeNull();
+	});
+
+	it('resolves only reviewed portable executor module identifiers', () => {
+		expect(executorModuleSpecifier('module:codex-chat')).toBe('@treeseed/agent/executors/codex-chat');
+		expect(() => executorModuleSpecifier('module:unknown')).toThrow(/Unknown capacity provider executor module/u);
 	});
 
 	it('creates one fresh private identity in local enrollment custody and reuses it on retry', async () => {


### PR DESCRIPTION
Closes #25\n\nMaps the validated portable module:codex-chat identifier to the published Agent executor export, fails closed for unknown identifiers, and publishes 0.13.0-rc.9.\n\nFocused evidence:\n- provider-boundary and provider-runner: 13 passed\n- build passed\n- file architecture passed