### PR TITLE
Publish usable Agent RC images and release bundles

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -77,7 +77,8 @@ jobs:
           fi
 
   build:
-    if: startsWith(github.ref, 'refs/tags/') && !contains(github.ref_name, '-')
+    needs: npm
+    if: startsWith(github.ref, 'refs/tags/')
     runs-on: ${{ matrix.runner }}
     permissions:
       contents: write
@@ -136,7 +137,7 @@ jobs:
 
   manifest:
     needs: build
-    if: startsWith(github.ref, 'refs/tags/') && !contains(github.ref_name, '-')
+    if: startsWith(github.ref, 'refs/tags/')
     runs-on: ubuntu-24.04
     permissions:
       contents: read
@@ -192,28 +193,82 @@ jobs:
             docker buildx imagetools inspect "${ref}" >/dev/null
             verify_attestation "${ref}"
           done
-  release:
+
+  component-release:
     needs: manifest
+    if: startsWith(github.ref, 'refs/tags/')
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: read
+      packages: read
+    environment: production
+    steps:
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262
+        with:
+          submodules: recursive
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020
+        with:
+          node-version: 24
+      - run: npm ci --ignore-scripts
+      - uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f
+      - uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9
+        with:
+          username: ${{ vars.TREESEED_DOCKERHUB_USERNAME }}
+          password: ${{ secrets.TREESEED_DOCKERHUB_TOKEN }}
+      - name: Read exact multi-architecture digests from Docker Hub
+        id: images
+        shell: bash
+        run: |
+          set -euo pipefail
+          version="${GITHUB_REF_NAME#v}"
+          manager="$(docker buildx imagetools inspect "treeseed/agent-manager:${version}" --format '{{json .Manifest}}' | jq -r '.digest')"
+          runner="$(docker buildx imagetools inspect "treeseed/agent-runner:${version}" --format '{{json .Manifest}}' | jq -r '.digest')"
+          [[ "${manager}" =~ ^sha256:[a-f0-9]{64}$ && "${runner}" =~ ^sha256:[a-f0-9]{64}$ ]]
+          echo "manager=${manager}" >> "$GITHUB_OUTPUT"
+          echo "runner=${runner}" >> "$GITHUB_OUTPUT"
+      - name: Build exact component release and production Compose bundle
+        env:
+          TREESEED_RELEASE: ${{ github.ref_name }}
+          TREESEED_SOURCE_COMMIT: ${{ github.sha }}
+          TREESEED_MANAGER_DIGEST: ${{ steps.images.outputs.manager }}
+          TREESEED_RUNNER_DIGEST: ${{ steps.images.outputs.runner }}
+        run: node --import tsx scripts/release/create-component-release.ts
+      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
+        with:
+          name: agent-component-release-${{ github.sha }}
+          path: release-assets/
+          if-no-files-found: error
+
+  release:
+    needs: [npm, manifest, component-release]
     if: startsWith(github.ref, 'refs/tags/') && !contains(github.ref_name, '-')
     runs-on: ubuntu-24.04
     permissions:
       contents: write
     steps:
       - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262
+      - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093
+        with:
+          name: agent-component-release-${{ github.sha }}
+          path: release-assets
       - name: Create GitHub release
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: gh release create "${GITHUB_REF_NAME}" --generate-notes --verify-tag
+        run: gh release create "${GITHUB_REF_NAME}" release-assets/* --generate-notes --verify-tag
 
   prerelease:
-    needs: npm
+    needs: [npm, manifest, component-release]
     if: startsWith(github.ref, 'refs/tags/') && contains(github.ref_name, '-rc.')
     runs-on: ubuntu-24.04
     permissions:
       contents: write
     steps:
       - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262
+      - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093
+        with:
+          name: agent-component-release-${{ github.sha }}
+          path: release-assets
       - name: Create GitHub prerelease
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: gh release create "${GITHUB_REF_NAME}" --generate-notes --verify-tag --prerelease
+        run: gh release create "${GITHUB_REF_NAME}" release-assets/* --generate-notes --verify-tag --prerelease

--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,7 @@ dist/
 .local/
 .treeseed/
 coverage/
+release-assets/
 playwright-report/
 test-results/
 tmp/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:22-alpine AS agent-provider-base
+FROM node:24-alpine AS agent-provider-base
 
 WORKDIR /app
 

--- a/deploy/compose.template.yml
+++ b/deploy/compose.template.yml
@@ -1,0 +1,51 @@
+name: treeseed-agent
+services:
+  manager:
+    image: "@MANAGER_IMAGE@"
+    command: ["manager"]
+    restart: unless-stopped
+    environment: &provider-environment
+      TREESEED_CAPACITY_PROVIDER_MANIFEST: /config/treeseed.capacity-provider.yaml
+      TREESEED_PROVIDER_DATA_DIR: /data
+      TREESEED_PROVIDER_ENVIRONMENT: managed
+      TREESEED_SERVER_PROFILE_LOCAL_URL: ${TREESEED_API_INTERNAL_URL:-http://api:3002}
+      TREESEED_SERVER_PROFILE_LOCAL_AUDIENCE: ${TREESEED_API_AUDIENCE:-https://api.treeseed.localhost}
+      TREESEED_AGENT_EXECUTOR_MODULE: ${TREESEED_AGENT_EXECUTOR_MODULE:-}
+      TREESEED_PROVIDER_MAX_CONCURRENT_WORKDAYS: ${TREESEED_PROVIDER_MAX_CONCURRENT_WORKDAYS:-1}
+      TREESEED_PROVIDER_MAX_CONCURRENT_RUNNERS: ${TREESEED_PROVIDER_MAX_CONCURRENT_RUNNERS:-1}
+    volumes: &provider-volumes
+      - type: bind
+        source: /var/lib/treeseed/components/agent
+        target: /data
+      - type: bind
+        source: /etc/treeseed/components/agent/treeseed.capacity-provider.yaml
+        target: /config/treeseed.capacity-provider.yaml
+        read_only: true
+    networks: [private, platform]
+    healthcheck:
+      test: ["CMD", "/app/docker-entrypoint.sh", "healthcheck", "--json"]
+      interval: 30s
+      timeout: 10s
+      retries: 5
+      start_period: 20s
+    security_opt: ["no-new-privileges:true"]
+  runner:
+    image: "@RUNNER_IMAGE@"
+    command: ["runner"]
+    restart: unless-stopped
+    environment: *provider-environment
+    volumes: *provider-volumes
+    networks: [private, platform]
+    healthcheck:
+      test: ["CMD", "/app/docker-entrypoint.sh", "healthcheck", "--json"]
+      interval: 30s
+      timeout: 10s
+      retries: 5
+      start_period: 20s
+    security_opt: ["no-new-privileges:true"]
+networks:
+  private:
+    internal: true
+  platform:
+    name: treeseed-platform
+    external: true

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,15 +1,15 @@
 {
   "name": "@treeseed/agent",
-  "version": "0.13.0-rc.9",
+  "version": "0.13.0-rc.10",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@treeseed/agent",
-      "version": "0.13.0-rc.9",
+      "version": "0.13.0-rc.10",
       "license": "Apache-2.0",
       "dependencies": {
-        "@treeseed/sdk": "0.13.0-rc.25",
+        "@treeseed/sdk": "0.13.0-rc.27",
         "esbuild": "0.28.2",
         "typescript": "^5.9.3",
         "yaml": "^2.8.1"
@@ -727,9 +727,9 @@
       "license": "MIT"
     },
     "node_modules/@treeseed/sdk": {
-      "version": "0.13.0-rc.25",
-      "resolved": "https://registry.npmjs.org/@treeseed/sdk/-/sdk-0.13.0-rc.25.tgz",
-      "integrity": "sha512-xzHZL/m7omxKB0Sn32yYiOoohx5L99jCCjLGEyZjhnalZk1GuMOj/F082VMx59wSY4ppY7D6EVGtdSfbzRXjiw==",
+      "version": "0.13.0-rc.27",
+      "resolved": "https://registry.npmjs.org/@treeseed/sdk/-/sdk-0.13.0-rc.27.tgz",
+      "integrity": "sha512-DOKY8Ahn7VxfHNqNU1pDUYFjWPn1X98jdSZPwrTy17TaZicSzeOtQ0cR7atGcBzzUBi5NwawzKJHwjWrZy2SeQ==",
       "license": "Apache-2.0",
       "dependencies": {
         "@treeseed/treedx": "0.3.0-rc.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@treeseed/agent",
-  "version": "0.13.0-rc.9",
+  "version": "0.13.0-rc.10",
   "description": "Treeseed agent service runtime package.",
   "license": "Apache-2.0",
   "repository": {
@@ -66,7 +66,7 @@
     "test:provider-runtime": "npm run test:modern"
   },
   "dependencies": {
-    "@treeseed/sdk": "0.13.0-rc.25",
+    "@treeseed/sdk": "0.13.0-rc.27",
     "esbuild": "0.28.2",
     "typescript": "^5.9.3",
     "yaml": "^2.8.1"

--- a/scripts/capacity/providers/build-capacity-provider-container.ts
+++ b/scripts/capacity/providers/build-capacity-provider-container.ts
@@ -127,20 +127,14 @@ function resolveSdkPackageRoot() {
 
 function resolveInstalledNodeModulesRoot() {
 	let current = packageRoot;
-	let lastCandidate: string | null = null;
 	while (true) {
 		const candidate = resolve(current, 'node_modules');
-		if (existsSync(candidate)) {
-			lastCandidate = candidate;
-		}
+		if (existsSync(candidate)) return candidate;
 		const parent = dirname(current);
 		if (parent === current) break;
 		current = parent;
 	}
-	if (!lastCandidate) {
-		throw new Error('Missing node_modules. Run npm install before building the capacity provider image.');
-	}
-	return lastCandidate;
+	throw new Error('Missing node_modules. Run npm install before building the capacity provider image.');
 }
 
 function packSdk() {
@@ -178,7 +172,7 @@ function prepareRuntimeDependencies(installedSdkRoot: string | null) {
 	copyFileSync(resolve(packageRoot, 'package-lock.json'), resolve(runtimeRoot, 'package-lock.json'));
 	mkdirSync(resolve(runtimeRoot, 'node_modules'), { recursive: true });
 	for (const packageName of runtimePackages) {
-		if (packageName.startsWith('@treeseed/')) continue;
+		if (packageName === '@treeseed/sdk') continue;
 		copyRuntimePackage(installedNodeModules, packageName, runtimeRoot);
 	}
 	mkdirSync(resolve(runtimeRoot, 'node_modules', '@treeseed'), { recursive: true });
@@ -208,7 +202,7 @@ function runtimePackageNames(installedNodeModules: string) {
 	const queue: string[] = [];
 	for (const [packagePath, metadata] of Object.entries(lockfile.packages ?? {})) {
 		if (!packagePath.startsWith('node_modules/') || metadata.dev === true) continue;
-		const packageName = topLevelPackageName(packagePath.slice('node_modules/'.length));
+		const packageName = topLevelPackageName(packagePath.split('node_modules/').at(-1) ?? '');
 		if (!packageName) continue;
 		if (!allowed.has(packageName)) {
 			allowed.add(packageName);
@@ -245,7 +239,12 @@ function installedPackageDependencies(installedNodeModules: string, packageName:
 }
 
 function copyRuntimePackage(installedNodeModules: string, packageName: string, runtimeRoot: string) {
-	const source = resolve(installedNodeModules, packageName);
+	let source = resolve(installedNodeModules, packageName);
+	if (!existsSync(source)) {
+		const lockfile = JSON.parse(readFileSync(resolve(packageRoot, 'package-lock.json'), 'utf8')) as { packages?: Record<string, unknown> };
+		const packagePath = Object.keys(lockfile.packages ?? {}).filter((candidate) => candidate.endsWith(`node_modules/${packageName}`)).sort((left, right) => left.length - right.length).find((candidate) => existsSync(resolve(packageRoot, candidate)));
+		if (packagePath) source = resolve(packageRoot, packagePath);
+	}
 	if (!existsSync(source)) return;
 	const target = resolve(runtimeRoot, 'node_modules', packageName);
 	mkdirSync(target, { recursive: true });

--- a/scripts/release/create-component-release.ts
+++ b/scripts/release/create-component-release.ts
@@ -1,0 +1,38 @@
+import { mkdirSync, readFileSync, writeFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { componentReleaseSchema, deploymentDigest } from '@treeseed/sdk/deployment';
+
+const release = process.env.TREESEED_RELEASE, sourceCommit = process.env.TREESEED_SOURCE_COMMIT;
+const managerDigest = process.env.TREESEED_MANAGER_DIGEST, runnerDigest = process.env.TREESEED_RUNNER_DIGEST;
+if (!release || !sourceCommit || !managerDigest || !runnerDigest) throw new Error('Release, exact source commit, and both multi-architecture image digests are required.');
+const digest = /^sha256:[a-f0-9]{64}$/u;
+if (!/^[a-f0-9]{40}$/u.test(sourceCommit) || !digest.test(managerDigest) || !digest.test(runnerDigest)) throw new Error('Source or image digest is malformed.');
+const track = release.includes('-rc.') ? 'development' : 'stable';
+const debianRelease = release.replace(/-rc\.(\d+)$/u, '~rc$1');
+const runtime = {
+	schemaVersion: 'treeseed.package-runtime/v1' as const, componentId: 'agent', version: debianRelease,
+	compose: { projectName: 'treeseed-agent', files: ['compose.yml'] },
+	services: [{ id: 'manager', composeService: 'manager', endpoints: [] }, { id: 'runner', composeService: 'runner', endpoints: [] }],
+	stateVolumes: [{ id: 'provider-data', volume: '/var/lib/treeseed/components/agent', backup: 'required' as const }],
+	migrations: [{ id: 'provider-identity', order: 0, backupRequired: true }], requiredCapabilities: ['docker-compose'],
+};
+const tagUrl = (repository: string) => `https://hub.docker.com/r/${repository}/tags?name=${encodeURIComponent(release)}`;
+const bundle = componentReleaseSchema.parse({
+	schemaVersion: 'treeseed.component-release/v1', componentId: 'agent', release: debianRelease, track,
+	source: { repository: 'treeseed-ai/agent', commit: sourceCommit },
+	stableBase: track === 'development' ? { releaseRange: '>=0.1.0 <0.2.0', compatibilityId: 'treeseed-linux-amd64-v1', catalogDigest: null } : null,
+	packages: [{ name: 'treeseed-component-agent', version: debianRelease, architecture: 'all', origin: 'TreeSeed Deployment', order: 30 }],
+	images: [
+		{ role: 'agent-manager', repository: 'treeseed/agent-manager', digest: managerDigest, platforms: ['linux/amd64', 'linux/arm64'], consumers: ['agent'] },
+		{ role: 'agent-runner', repository: 'treeseed/agent-runner', digest: runnerDigest, platforms: ['linux/amd64', 'linux/arm64'], consumers: ['agent'] },
+	],
+	runtime, runtimeDigest: deploymentDigest(runtime), rollback: { compatible: true, requiresBackup: true },
+	evidence: { provenance: [tagUrl('treeseed/agent-manager'), tagUrl('treeseed/agent-runner')], sboms: [tagUrl('treeseed/agent-manager'), tagUrl('treeseed/agent-runner')], vulnerabilities: [] },
+});
+const output = resolve('release-assets'); mkdirSync(output, { recursive: true });
+const template = readFileSync(resolve('deploy/compose.template.yml'), 'utf8');
+const compose = template.replace('@MANAGER_IMAGE@', `treeseed/agent-manager@${managerDigest}`).replace('@RUNNER_IMAGE@', `treeseed/agent-runner@${runnerDigest}`);
+if (/\bbuild\s*:/u.test(compose) || /@(?:MANAGER|RUNNER)_IMAGE@/u.test(compose)) throw new Error('Production Compose bundle is not fully materialized.');
+writeFileSync(resolve(output, 'compose.yml'), compose);
+writeFileSync(resolve(output, 'component-release.json'), `${JSON.stringify(bundle, null, 2)}\n`);
+console.log(JSON.stringify({ ok: true, release, sourceCommit, managerDigest, runnerDigest, runtimeDigest: bundle.runtimeDigest }));

--- a/tests/modern/release-publication.test.ts
+++ b/tests/modern/release-publication.test.ts
@@ -1,0 +1,37 @@
+import { execFileSync } from 'node:child_process';
+import { readFileSync, rmSync } from 'node:fs';
+import { parse } from 'yaml';
+import { afterEach, describe, expect, it } from 'vitest';
+
+const hash = (marker: string) => `sha256:${marker.repeat(64)}`;
+afterEach(() => rmSync('release-assets', { recursive: true, force: true }));
+
+describe('Agent RC publication', () => {
+	it('runs RC tags through architecture builds, manifests, read-back, and component release', () => {
+		const workflow = parse(readFileSync('.github/workflows/publish.yml', 'utf8')) as { jobs: Record<string, { if?: string; needs?: string | string[] }> };
+		expect(workflow.jobs.build?.if).toBe("startsWith(github.ref, 'refs/tags/')");
+		expect(workflow.jobs.build?.needs).toBe('npm');
+		expect(workflow.jobs.manifest?.if).toBe("startsWith(github.ref, 'refs/tags/')");
+		expect(workflow.jobs['component-release']?.needs).toBe('manifest');
+		expect(workflow.jobs.prerelease?.needs).toEqual(['npm', 'manifest', 'component-release']);
+	});
+
+	it('materializes an exact no-build production bundle', () => {
+		execFileSync(process.execPath, ['--import', 'tsx', 'scripts/release/create-component-release.ts'], { env: { ...process.env, TREESEED_RELEASE: '0.13.0-rc.10', TREESEED_SOURCE_COMMIT: 'a'.repeat(40), TREESEED_MANAGER_DIGEST: hash('b'), TREESEED_RUNNER_DIGEST: hash('c') } });
+		const compose = readFileSync('release-assets/compose.yml', 'utf8');
+		const release = JSON.parse(readFileSync('release-assets/component-release.json', 'utf8')) as { track: string; source: { commit: string }; stableBase: { catalogDigest: unknown }; images: Array<{ digest: string }> };
+		expect(compose).not.toMatch(/\bbuild\s*:/u);
+		expect(compose).toContain(`treeseed/agent-manager@${hash('b')}`);
+		expect(release.track).toBe('development');
+		expect(release.source.commit).toBe('a'.repeat(40));
+		expect(release.stableBase.catalogDigest).toBeNull();
+		expect(release.images.map((image) => image.digest)).toEqual([hash('b'), hash('c')]);
+	});
+
+	it('includes SDK transitive TreeSeed packages in the image closure', () => {
+		const builder = readFileSync('scripts/capacity/providers/build-capacity-provider-container.ts', 'utf8');
+		expect(builder).toContain("if (packageName === '@treeseed/sdk') continue;");
+		expect(builder).not.toContain("packageName.startsWith('@treeseed/')");
+		expect(readFileSync('Dockerfile', 'utf8')).toContain('FROM node:24-alpine');
+	});
+});

--- a/treeseed.package.yaml
+++ b/treeseed.package.yaml
@@ -75,3 +75,17 @@ projectArchitecture:
   contentPublishTarget:
     kind: cloudflare_r2
     prefix: packages/agent
+packageRuntime:
+  schemaVersion: treeseed.package-runtime/v1
+  componentId: agent
+  services:
+    - id: manager
+      composeService: manager
+      healthGate:
+        kind: compose-healthcheck
+        timeoutSeconds: 60
+      endpoints: []
+    - id: runner
+      composeService: runner
+      endpoints: []
+  defaultAliases: []


### PR DESCRIPTION
## Outcome

Makes every valid Agent RC tag publish a usable npm candidate plus manager/runner OCI images for amd64 and arm64, multi-architecture RC manifests, BuildKit provenance/SBOM attestations, Docker Hub read-back, and an exact component-release/production Compose bundle. Fixes the image runtime closure that previously omitted SDK transitive TreeSeed packages and failed health checks.

## Work authority

- Work item / Issue: Closes #27
- Proposal / decision: Unified TreeSeed Deployment, Lab, and Local-Host Cutover campaign
- Assignment / checkpoint: Agent RC dependency step 3
- Actor: Codex
- Human authority: Adrian
- Agent / capacity provider: Codex desktop task
- Exact base ref: staging at dfdda15d9aa72d14cb88186965c3bb5bf3b60c6c
- Exact head ref: codex/rc-image-publication at 307af39cf32c9bf3d65ea9ac4b74e0d6162f3122

Contributor mode (select one):

- [ ] Human-authored
- [x] Agent-assisted under human authority
- [ ] Agent-authored under human authority

## Plan

1. Advance to 0.13.0-rc.10 and SDK 0.13.0-rc.27.
2. Remove the stable-only image/manifest gates while preserving npm `latest` for RCs.
3. Gate images after npm, create/read back both architecture manifests and attestations.
4. Publish exact digests in a no-build managed Compose bundle and component-release JSON.
5. Correct and prove the image dependency closure and Node 24 runtime.

## Changes and commits

- 307af39cf32c9bf3d65ea9ac4b74e0d6162f3122 — Publish usable Agent RC images and release bundles
- RC release order is npm → four architecture builds → two manifests/read-back → component bundle → prerelease.
- `latest` remains untouched for RC npm publication; no moving Docker tag is emitted.

## Verification

- `npm ci --ignore-scripts --workspaces=false`
- `npm run verify:local`: 5 test files / 19 tests plus packed-install acceptance passed.
- `npm run capacity-provider:build -- --prepare-only`: exact runtime closure prepared and contains `@treeseed/treedx` and `zod`.
- Native local Docker builds passed for both `agent-manager` and `agent-runner` targets on Node 24.
- `docker run --rm ... healthcheck --json` returned `ok: true` for both targets.
- The first local proof failed on missing `@treeseed/treedx`, then missing nested `zod`; both closure defects are fixed and covered before publication.
- Generated component release validates against SDK 0.13.0-rc.27 and contains only digest-pinned images; generated production Compose contains no `build:`.

## Risk and rollback

The release workflow now publishes four more RC image artifacts and therefore takes longer. Each tag is immutable and no stable/moving tag changes for RCs. Roll back by reverting this commit before tagging. After tagging, retain the immutable RC evidence and publish a corrected next RC rather than rewriting tags or manifests.

## Completion summary

Agent RCs are now eligible for the continuously updated managed development capacity-provider track. The exact stable catalog digest remains intentionally null in the project bundle and becomes mandatory when Deployment ingests it, preventing a publication-order cycle without weakening activation safety.

## Submission checklist

- [x] The change is bounded to the stated work item and target repository.
- [x] Exact base and head refs are recorded and the branch is ready for review.
- [x] Verification and compatibility evidence are recorded above.
- [x] No plaintext secrets, credentials, machine state, or unrelated residue are included.
- [x] Plan, status, commits, and completion summary form a complete durable record.
- [x] Rollback or recovery steps are documented and executable.
