### PR TITLE
Fix clean Agent RC image builds

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -112,6 +112,9 @@ jobs:
       - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262
         with:
           submodules: recursive
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020
+        with:
+          node-version: 24
       - run: npm ci --ignore-scripts
       - run: npm run capacity-provider:build -- --prepare-only
       - name: Compute image tags

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@treeseed/agent",
-  "version": "0.13.0-rc.10",
+  "version": "0.13.0-rc.11",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@treeseed/agent",
-      "version": "0.13.0-rc.10",
+      "version": "0.13.0-rc.11",
       "license": "Apache-2.0",
       "dependencies": {
         "@treeseed/sdk": "0.13.0-rc.27",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@treeseed/agent",
-  "version": "0.13.0-rc.10",
+  "version": "0.13.0-rc.11",
   "description": "Treeseed agent service runtime package.",
   "license": "Apache-2.0",
   "repository": {

--- a/scripts/capacity/providers/build-capacity-provider-container.ts
+++ b/scripts/capacity/providers/build-capacity-provider-container.ts
@@ -105,7 +105,7 @@ function resolveSdkPackageRoot() {
 	if (existsSync(resolve(siblingRoot, 'package.json'))) {
 		return siblingRoot;
 	}
-	let current = dirname(require.resolve('@treeseed/sdk', { paths: [packageRoot] }));
+	let current = dirname(require.resolve('@treeseed/sdk/standards', { paths: [packageRoot] }));
 	while (true) {
 		const candidate = resolve(current, 'package.json');
 		if (existsSync(candidate)) {


### PR DESCRIPTION
## Outcome

Prepares the next immutable Agent candidate, 0.13.0-rc.11, after rc.10 correctly stopped at its image gate. Fixes SDK discovery in a clean checkout and explicitly provisions Node 24 in every architecture build job.

## Work authority

- Work item / Issue: Follow-up to #27
- Proposal / decision: Unified deployment campaign corrected-RC policy
- Assignment / checkpoint: Agent RC publication checkpoint 1
- Actor: Codex
- Human authority: Adrian
- Agent / capacity provider: Codex desktop task
- Exact base ref: staging at fe644e5b20ac60c6f6c2e72e3e2b024ba1e2b642
- Exact head ref: codex/rc-image-publication-fix at 0e3262f98a565cad9def0f317eb631ffd4ceb390

Contributor mode (select one):

- [ ] Human-authored
- [x] Agent-assisted under human authority
- [ ] Agent-authored under human authority

## Plan

Use an exported SDK subpath to discover the installed package root, install Node 24 in image jobs, and publish a new RC rather than changing rc.10.

## Changes and commits

- 0e3262f98a565cad9def0f317eb631ffd4ceb390 — Fix clean Agent RC image builds

## Verification

- `npm run verify:local`: 19 tests and packed-install acceptance passed.
- Isolated clean clone with no sibling SDK: `npm ci`, capacity-provider preparation, transitive TreeDX/zod closure checks, Docker manager build, and JSON healthcheck all passed.
- rc.10 npm publication succeeded without moving `latest`; its image jobs failed before pushing images.

## Risk and rollback

The change is confined to build-time SDK discovery and Node provisioning. Revert before tagging if checks fail. After tagging, publish another corrected RC; never rewrite rc.11.

## Completion summary

This addresses the exact clean-runner failure observed in the first campaign publication attempt and supplies direct isolated reproduction evidence.

## Submission checklist

- [x] The change is bounded to the stated work item and target repository.
- [x] Exact base and head refs are recorded and the branch is ready for review.
- [x] Verification and compatibility evidence are recorded above.
- [x] No plaintext secrets, credentials, machine state, or unrelated residue are included.
- [x] Plan, status, commits, and completion summary form a complete durable record.
- [x] Rollback or recovery steps are documented and executable.

