### PR TITLE
Ship a usable Codex runtime in Agent RC images

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -137,6 +137,15 @@ jobs:
           tags: ${{ matrix.image }}:${{ steps.tags.outputs.base }}-${{ matrix.arch }}
           sbom: true
           provenance: mode=max
+      - name: Verify the published runner contains Codex
+        if: matrix.target == 'agent-runner'
+        shell: bash
+        run: |
+          set -euo pipefail
+          image="${{ matrix.image }}:${{ steps.tags.outputs.base }}-${{ matrix.arch }}"
+          docker pull "${image}"
+          version="$(docker run --rm --entrypoint /usr/local/bin/codex "${image}" --version)"
+          [[ "${version}" == "codex-cli 0.149.0" ]]
 
   manifest:
     needs: build

--- a/Dockerfile
+++ b/Dockerfile
@@ -21,6 +21,9 @@ FROM agent-provider-base AS agent-runtime
 COPY --chown=65532:65532 .treeseed/docker/runtime/shared/package.json .treeseed/docker/runtime/shared/package-lock.json ./
 COPY --chown=65532:65532 .treeseed/docker/runtime/shared/node_modules ./node_modules
 
+RUN test -x /app/node_modules/@openai/codex/bin/codex.js \
+	&& ln -s /app/node_modules/@openai/codex/bin/codex.js /usr/local/bin/codex
+
 FROM agent-runtime AS agent-manager
 ENV TREESEED_PROVIDER_ROLE=manager
 CMD ["manager"]

--- a/compose.capacity-provider.yml
+++ b/compose.capacity-provider.yml
@@ -15,7 +15,10 @@ services:
       TREESEED_PROVIDER_SOURCE_CLOSURE_DIGEST: ${TREESEED_PROVIDER_SOURCE_CLOSURE_DIGEST:-}
       TREESEED_SERVER_PROFILE_LOCAL_URL: ${TREESEED_SERVER_PROFILE_LOCAL_URL:-http://host.docker.internal:3002}
       TREESEED_SERVER_PROFILE_LOCAL_AUDIENCE: ${TREESEED_SERVER_PROFILE_LOCAL_AUDIENCE:-http://127.0.0.1:3002}
-      TREESEED_AGENT_EXECUTOR_MODULE: ${TREESEED_AGENT_EXECUTOR_MODULE:-}
+      TREESEED_AGENT_EXECUTOR_MODULE: ${TREESEED_AGENT_EXECUTOR_MODULE:-module:codex-chat}
+      TREESEED_CODEX_EXECUTABLE: /usr/local/bin/codex
+      TREESEED_CODEX_AUTH_SOURCE: /run/treeseed-secrets/codex-auth.json
+      TREESEED_CODEX_AUTH_FILE: /data/credentials/codex-auth.json
       TREESEED_PROVIDER_MAX_CONCURRENT_WORKDAYS: ${TREESEED_PROVIDER_MAX_CONCURRENT_WORKDAYS:-1}
       TREESEED_PROVIDER_MAX_CONCURRENT_RUNNERS: ${TREESEED_PROVIDER_MAX_CONCURRENT_RUNNERS:-1}
       TREESEED_PROVIDER_DAILY_AGENT_SECONDS_LIMIT: ${TREESEED_PROVIDER_DAILY_AGENT_SECONDS_LIMIT:-}
@@ -24,6 +27,7 @@ services:
     volumes: &provider-volumes
       - "${TREESEED_PROVIDER_HOST_DATA_DIR:-.treeseed/local-capacity-providers/agent-standalone}:/data"
       - "${TREESEED_CAPACITY_PROVIDER_MANIFEST:-./treeseed.capacity-provider.yaml}:/config/treeseed.capacity-provider.yaml:ro"
+      - "${TREESEED_CODEX_AUTH_HOST_FILE:-${HOME}/.codex/auth.json}:/run/treeseed-secrets/codex-auth.json:ro"
   runner:
     image: ${TREESEED_AGENT_RUNNER_IMAGE:-treeseed/agent-runner:${TREESEED_AGENT_IMAGE_TAG:-local}}
     build:

--- a/deploy/compose.template.yml
+++ b/deploy/compose.template.yml
@@ -10,7 +10,10 @@ services:
       TREESEED_PROVIDER_ENVIRONMENT: managed
       TREESEED_SERVER_PROFILE_LOCAL_URL: ${TREESEED_API_INTERNAL_URL:-http://api:3002}
       TREESEED_SERVER_PROFILE_LOCAL_AUDIENCE: ${TREESEED_API_AUDIENCE:-https://api.treeseed.localhost}
-      TREESEED_AGENT_EXECUTOR_MODULE: ${TREESEED_AGENT_EXECUTOR_MODULE:-}
+      TREESEED_AGENT_EXECUTOR_MODULE: ${TREESEED_AGENT_EXECUTOR_MODULE:-module:codex-chat}
+      TREESEED_CODEX_EXECUTABLE: /usr/local/bin/codex
+      TREESEED_CODEX_AUTH_SOURCE: /run/treeseed-secrets/codex-auth.json
+      TREESEED_CODEX_AUTH_FILE: /data/credentials/codex-auth.json
       TREESEED_PROVIDER_MAX_CONCURRENT_WORKDAYS: ${TREESEED_PROVIDER_MAX_CONCURRENT_WORKDAYS:-1}
       TREESEED_PROVIDER_MAX_CONCURRENT_RUNNERS: ${TREESEED_PROVIDER_MAX_CONCURRENT_RUNNERS:-1}
     volumes: &provider-volumes
@@ -20,6 +23,10 @@ services:
       - type: bind
         source: /etc/treeseed/components/agent/treeseed.capacity-provider.yaml
         target: /config/treeseed.capacity-provider.yaml
+        read_only: true
+      - type: bind
+        source: /etc/treeseed/credentials/agent-codex-auth
+        target: /run/treeseed-secrets/codex-auth.json
         read_only: true
     networks: [private, platform]
     healthcheck:

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -5,12 +5,28 @@ DATA_DIR="${TREESEED_PROVIDER_DATA_DIR:-/data}"
 APP_UID="${TREESEED_PROVIDER_UID:-65532}"
 APP_GID="${TREESEED_PROVIDER_GID:-65532}"
 CHOWN_DATA="${TREESEED_PROVIDER_CHOWN_DATA:-1}"
+CODEX_AUTH_SOURCE="${TREESEED_CODEX_AUTH_SOURCE:-}"
+CODEX_AUTH_FILE="${TREESEED_CODEX_AUTH_FILE:-$DATA_DIR/credentials/codex-auth.json}"
 
 mkdir -p "$DATA_DIR"
 
 if [ "$(id -u)" = "0" ]; then
 	if [ "$CHOWN_DATA" != "0" ]; then
 		chown -R "$APP_UID:$APP_GID" "$DATA_DIR"
+	fi
+	if [ -n "$CODEX_AUTH_SOURCE" ]; then
+		if [ ! -f "$CODEX_AUTH_SOURCE" ] || [ -L "$CODEX_AUTH_SOURCE" ]; then
+			echo "Codex authentication source must be a regular, non-symlink file." >&2
+			exit 78
+		fi
+		case "$CODEX_AUTH_FILE" in
+			"$DATA_DIR"/credentials/*) ;;
+			*) echo "Codex authentication target must remain in the provider credential directory." >&2; exit 78 ;;
+		esac
+		mkdir -p "$(dirname "$CODEX_AUTH_FILE")"
+		cp "$CODEX_AUTH_SOURCE" "$CODEX_AUTH_FILE"
+		chmod 0600 "$CODEX_AUTH_FILE"
+		chown "$APP_UID:$APP_GID" "$CODEX_AUTH_FILE"
 	fi
 	exec setpriv --reuid "$APP_UID" --regid "$APP_GID" --clear-groups node ./dist/provider/lifecycle/entrypoint.js "$@"
 fi

--- a/docs/capacity-provider-runtime.md
+++ b/docs/capacity-provider-runtime.md
@@ -13,6 +13,8 @@ The package does not host an API, persist control-plane records, synthesize work
 
 Model/runtime implementation is injected through `TREESEED_AGENT_EXECUTOR_MODULE`. The module must export `createAgentExecutor()` and implement the package's `AgentExecutor` contract. Without a configured and healthy executor, the manager advertises no executable capacity and the runner does not request work.
 
+The published manager and runner images include the exact Codex CLI version declared by the package lock. The managed production bundle defaults to the built-in `module:codex-chat` executor and accepts the Codex login cache only from the root-owned `/etc/treeseed/credentials/agent-codex-auth` host file. The root entrypoint validates that mount, copies it with mode `0600` into manager-owned provider state, and drops privileges before starting Node. Each assignment then uses an isolated temporary `CODEX_HOME` and deletes it after execution. Credentials must never be baked into an image, supplied through an environment variable, or committed to a repository.
+
 The executor receives only an API-issued assignment, lease identity, runner identity, and cancellation signal. Repository, TreeDX, model, and provider credentials must arrive through trusted provider receipts or host custody; they do not belong in agent definitions or source worktrees.
 
 ## Local profile

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,14 +1,15 @@
 {
   "name": "@treeseed/agent",
-  "version": "0.13.0-rc.11",
+  "version": "0.13.0-rc.12",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@treeseed/agent",
-      "version": "0.13.0-rc.11",
+      "version": "0.13.0-rc.12",
       "license": "Apache-2.0",
       "dependencies": {
+        "@openai/codex": "0.149.0",
         "@treeseed/sdk": "0.13.0-rc.27",
         "esbuild": "0.28.2",
         "typescript": "^5.9.3",
@@ -445,6 +446,128 @@
       "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@openai/codex": {
+      "version": "0.149.0",
+      "resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.149.0.tgz",
+      "integrity": "sha512-i4dryj2Y1j+00Mb5n+0n71EYnTK9/KDc2cdFo/dXD0d1oTog2bhUssKDEIOnKmnEf51P0Z/HJTWvTKw/UHyOvQ==",
+      "license": "Apache-2.0",
+      "bin": {
+        "codex": "bin/codex.js"
+      },
+      "engines": {
+        "node": ">=16"
+      },
+      "optionalDependencies": {
+        "@openai/codex-darwin-arm64": "npm:@openai/codex@0.149.0-darwin-arm64",
+        "@openai/codex-darwin-x64": "npm:@openai/codex@0.149.0-darwin-x64",
+        "@openai/codex-linux-arm64": "npm:@openai/codex@0.149.0-linux-arm64",
+        "@openai/codex-linux-x64": "npm:@openai/codex@0.149.0-linux-x64",
+        "@openai/codex-win32-arm64": "npm:@openai/codex@0.149.0-win32-arm64",
+        "@openai/codex-win32-x64": "npm:@openai/codex@0.149.0-win32-x64"
+      }
+    },
+    "node_modules/@openai/codex-darwin-arm64": {
+      "name": "@openai/codex",
+      "version": "0.149.0-darwin-arm64",
+      "resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.149.0-darwin-arm64.tgz",
+      "integrity": "sha512-GsZJbzBWiD48RETrO8VHGAQNgfSrUVxItXZFeD87wswatPi0+lKuQo8Dx4nMYmOZhZrVtwr3al/feRrZxnDV8Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@openai/codex-darwin-x64": {
+      "name": "@openai/codex",
+      "version": "0.149.0-darwin-x64",
+      "resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.149.0-darwin-x64.tgz",
+      "integrity": "sha512-H+mMgW3Nhc5QzGWEklCoFqACuOc0cVpgPkPQRw0LShoK7P5664T6BRnyl1yzT6orKPKv49cXry7DIWWZ19SanQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@openai/codex-linux-arm64": {
+      "name": "@openai/codex",
+      "version": "0.149.0-linux-arm64",
+      "resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.149.0-linux-arm64.tgz",
+      "integrity": "sha512-fAXPpvIob+11RNZJS9CVVTsKb+V4Hw3woGFPj42D7fU2wBJUKI2jfAc4fLJNtrpwRecLeW601mtkMHOSIbWuuA==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@openai/codex-linux-x64": {
+      "name": "@openai/codex",
+      "version": "0.149.0-linux-x64",
+      "resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.149.0-linux-x64.tgz",
+      "integrity": "sha512-uZXaN9JPxu0/jjnqqJeTd4kRYPnjVZK3MiVndfG1mHhEaoDKL7ScWHfPqvAEOjwsSDEmQSlMfUkmvYp/CHciYw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@openai/codex-win32-arm64": {
+      "name": "@openai/codex",
+      "version": "0.149.0-win32-arm64",
+      "resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.149.0-win32-arm64.tgz",
+      "integrity": "sha512-pUd8MzuwtqT5DhM1NUE1gETWIZ9fkDA1XB7tt9YNIi/peUgLuziQgZd7o0bNON4cNzgbil1YUN1qDTgQm0g3pg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@openai/codex-win32-x64": {
+      "name": "@openai/codex",
+      "version": "0.149.0-win32-x64",
+      "resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.149.0-win32-x64.tgz",
+      "integrity": "sha512-qKbwSOOO/fdhQ5MlXE2fts6taPxRPZ/zqeC+eqHD72hLRymV9rFCUbUxOCquognUPRPvS/2/kRCV0UVhoDd3yQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=16"
+      }
     },
     "node_modules/@oxc-project/types": {
       "version": "0.143.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@treeseed/agent",
-  "version": "0.13.0-rc.11",
+  "version": "0.13.0-rc.12",
   "description": "Treeseed agent service runtime package.",
   "license": "Apache-2.0",
   "repository": {
@@ -66,6 +66,7 @@
     "test:provider-runtime": "npm run test:modern"
   },
   "dependencies": {
+    "@openai/codex": "0.149.0",
     "@treeseed/sdk": "0.13.0-rc.27",
     "esbuild": "0.28.2",
     "typescript": "^5.9.3",

--- a/tests/modern/release-publication.test.ts
+++ b/tests/modern/release-publication.test.ts
@@ -34,4 +34,18 @@ describe('Agent RC publication', () => {
 		expect(builder).not.toContain("packageName.startsWith('@treeseed/')");
 		expect(readFileSync('Dockerfile', 'utf8')).toContain('FROM node:24-alpine');
 	});
+
+	it('ships an exact Codex runtime with manager-controlled credential custody', () => {
+		const packageJson = JSON.parse(readFileSync('package.json', 'utf8')) as { dependencies: Record<string, string> };
+		const dockerfile = readFileSync('Dockerfile', 'utf8');
+		const entrypoint = readFileSync('docker-entrypoint.sh', 'utf8');
+		const compose = readFileSync('deploy/compose.template.yml', 'utf8');
+		const workflow = readFileSync('.github/workflows/publish.yml', 'utf8');
+		expect(packageJson.dependencies['@openai/codex']).toBe('0.149.0');
+		expect(dockerfile).toContain('/app/node_modules/@openai/codex/bin/codex.js');
+		expect(entrypoint).toContain('Codex authentication source must be a regular, non-symlink file.');
+		expect(compose).toContain('/etc/treeseed/credentials/agent-codex-auth');
+		expect(compose).toContain('TREESEED_CODEX_AUTH_FILE: /data/credentials/codex-auth.json');
+		expect(workflow).toContain('codex-cli 0.149.0');
+	});
 });


### PR DESCRIPTION
Closes #27

## Outcome
- pins and packages Codex CLI 0.149.0 in both published provider images
- defaults the managed bundle to the built-in Codex chat executor
- transfers the root-owned host login cache into mode-0600 provider custody before dropping privileges
- retains per-assignment ephemeral CODEX_HOME isolation
- verifies the published runner image can execute the exact Codex CLI

## Evidence
- `npm run verify:direct`
- local production Compose parse
- local runner image build and `codex --version` read-back
- local root-entrypoint credential copy verified as mode 0600, uid/gid 65532

The credential handling follows the official Codex headless guidance: `auth.json` is password-equivalent and must stay outside images, repositories, environment variables, and logs.