### PR TITLE
Keep Agent health checks outside root provisioning

### DIFF
--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -8,6 +8,10 @@ CHOWN_DATA="${TREESEED_PROVIDER_CHOWN_DATA:-1}"
 CODEX_AUTH_SOURCE="${TREESEED_CODEX_AUTH_SOURCE:-}"
 CODEX_AUTH_FILE="${TREESEED_CODEX_AUTH_FILE:-$DATA_DIR/credentials/codex-auth.json}"
 
+if [ "$(id -u)" = "0" ] && [ "${1:-}" = "healthcheck" ]; then
+	exec setpriv --reuid "$APP_UID" --regid "$APP_GID" --clear-groups node ./dist/provider/lifecycle/entrypoint.js "$@"
+fi
+
 mkdir -p "$DATA_DIR"
 
 if [ "$(id -u)" = "0" ]; then

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@treeseed/agent",
-  "version": "0.13.0-rc.12",
+  "version": "0.13.0-rc.13",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@treeseed/agent",
-      "version": "0.13.0-rc.12",
+      "version": "0.13.0-rc.13",
       "license": "Apache-2.0",
       "dependencies": {
         "@openai/codex": "0.149.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@treeseed/agent",
-  "version": "0.13.0-rc.12",
+  "version": "0.13.0-rc.13",
   "description": "Treeseed agent service runtime package.",
   "license": "Apache-2.0",
   "repository": {

--- a/tests/modern/release-publication.test.ts
+++ b/tests/modern/release-publication.test.ts
@@ -44,6 +44,7 @@ describe('Agent RC publication', () => {
 		expect(packageJson.dependencies['@openai/codex']).toBe('0.149.0');
 		expect(dockerfile).toContain('/app/node_modules/@openai/codex/bin/codex.js');
 		expect(entrypoint).toContain('Codex authentication source must be a regular, non-symlink file.');
+		expect(entrypoint).toContain('[ "${1:-}" = "healthcheck" ]');
 		expect(compose).toContain('/etc/treeseed/credentials/agent-codex-auth');
 		expect(compose).toContain('TREESEED_CODEX_AUTH_FILE: /data/credentials/codex-auth.json');
 		expect(workflow).toContain('codex-cli 0.149.0');


### PR DESCRIPTION
Follow-up to #30.

## Outcome
Docker health checks now drop to the provider UID before executing any data ownership or credential provisioning path. This prevents the 30-second health probe from recursively changing state ownership or copying the Codex login cache. Version advances to the next unused candidate, `0.13.0-rc.13`.

## Evidence
- `npm run verify:direct`
- container health check ran as the provider UID
- a mounted root-owned data directory remained unchanged
- no credential target was created during the health check

RC12 remains immutable; Deployment will consume RC13.