### PR TITLE
Reconcile pending provider registrations automatically

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@treeseed/agent",
-  "version": "0.13.0-rc.14",
+  "version": "0.13.0-rc.15",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@treeseed/agent",
-      "version": "0.13.0-rc.14",
+      "version": "0.13.0-rc.15",
       "license": "Apache-2.0",
       "dependencies": {
         "@openai/codex": "0.149.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@treeseed/agent",
-  "version": "0.13.0-rc.14",
+  "version": "0.13.0-rc.15",
   "description": "Treeseed agent service runtime package.",
   "license": "Apache-2.0",
   "repository": {

--- a/src/provider/coordination/connection-state.ts
+++ b/src/provider/coordination/connection-state.ts
@@ -1,4 +1,4 @@
-import { mkdir, readFile, rename, unlink, writeFile } from 'node:fs/promises';
+import { mkdir, readFile, readdir, rename, unlink, writeFile } from 'node:fs/promises';
 import { dirname, resolve } from 'node:path';
 import type { ProviderSupplyOffer } from '@treeseed/sdk/capacity-provider/contracts';
 
@@ -42,6 +42,18 @@ export async function writeProviderConnectionState(dataDir: string, state: Provi
 	await writeFile(temporary, `${JSON.stringify(state, null, 2)}\n`, { encoding: 'utf8', mode: 0o600, flag: 'wx' });
 	await rename(temporary, path);
 	return state;
+}
+
+export async function listProviderConnectionStates(dataDir: string) {
+	const directory = resolve(dataDir, 'connections');
+	let names: string[];
+	try { names = await readdir(directory); }
+	catch (error) {
+		if ((error as NodeJS.ErrnoException).code === 'ENOENT') return [];
+		throw error;
+	}
+	const states = await Promise.all(names.filter((name) => /^[a-z0-9_.-]+\.json$/iu.test(name)).sort().map(async (name) => JSON.parse(await readFile(resolve(directory, name), 'utf8')) as ProviderConnectionState));
+	return states.filter((state) => state.schemaVersion === 1 && typeof state.connectionId === 'string' && typeof state.registrationRequestId === 'string');
 }
 
 export async function removeProviderConnectionState(dataDir: string, connectionId: string) {

--- a/src/provider/coordination/coordinator.ts
+++ b/src/provider/coordination/coordinator.ts
@@ -11,6 +11,7 @@ import { CONTROL_PLANE_OPERATIONS } from '@treeseed/sdk/operator-contracts';
 import { providerOperationPath } from './client.ts';
 import {
 	generatedMembershipCredentialRef,
+	listProviderConnectionStates,
 	removeProviderConnectionState,
 	readProviderConnectionState,
 	writeProviderConnectionState,
@@ -262,7 +263,15 @@ export class CapacityProviderCoordinator {
 	}
 
 	async reconcileAll() {
-		return Promise.all(this.loaded.manifest.connections.map(async (connection) => {
+		const configured = new Set(this.loaded.manifest.connections.map((connection) => connection.id));
+		const pending = (await listProviderConnectionStates(this.dataDir)).filter((state) => !configured.has(state.connectionId));
+		const pendingResults = await Promise.all(pending.map(async (state) => {
+			try { return await this.exchangeRegistrationCredential(state.connectionId); }
+			catch (error) {
+				return { connectionId: state.connectionId, status: 'error' as const, teamId: state.teamId ?? null, providerId: state.providerId ?? null, membershipId: state.membershipId ?? null, requestId: state.registrationRequestId ?? null, error: error instanceof Error ? error.message : String(error) };
+			}
+		}));
+		const configuredResults = await Promise.all(this.loaded.manifest.connections.map(async (connection) => {
 			try {
 				return await this.reconcileConnection(connection);
 			} catch (error) {
@@ -276,6 +285,7 @@ export class CapacityProviderCoordinator {
 				};
 			}
 		}));
+		return [...pendingResults, ...configuredResults].sort((left, right) => left.connectionId.localeCompare(right.connectionId));
 	}
 
 	async leaveConnection(connectionId: string) {

--- a/tests/modern/provider-boundary.test.ts
+++ b/tests/modern/provider-boundary.test.ts
@@ -7,6 +7,7 @@ import { providerOperationPath } from '../../src/provider/coordination/client.ts
 import { executorModuleSpecifier, resolveAgentExecutor } from '../../src/provider/execution/executor-loader.ts';
 import { resolveProviderConfig } from '../../src/provider/configuration/config.ts';
 import { ensureCapacityProviderIdentity } from '../../src/provider/accounts/identity.ts';
+import { listProviderConnectionStates, writeProviderConnectionState } from '../../src/provider/coordination/connection-state.ts';
 import { loadProviderManifest, writeProviderConnections } from '../../src/provider/configuration/manifest.ts';
 import { buildProviderPlan, providerAvailabilityCapabilities } from '../../src/provider/lifecycle/lifecycle.ts';
 import { stringify as stringifyYaml } from 'yaml';
@@ -90,6 +91,14 @@ describe('Agent package ownership boundary', () => {
 		} finally {
 			rmSync(root, { recursive: true, force: true });
 		}
+	});
+
+	it('discovers durable pending registrations for automatic approval polling', async () => {
+		const root = mkdtempSync(resolve(tmpdir(), 'treeseed-provider-pending-'));
+		try {
+			await writeProviderConnectionState(root, { schemaVersion: 1, connectionId: 'primary', controlPlaneUrl: 'https://api.example.test', controlPlaneAudience: 'https://api.example.test', offer: { maxConcurrentRunners: 1, capabilities: ['communication'] }, registrationRequestId: 'request-1', registrationStatus: 'pending', updatedAt: new Date().toISOString() });
+			expect((await listProviderConnectionStates(root)).map((state) => state.connectionId)).toEqual(['primary']);
+		} finally { rmSync(root, { recursive: true, force: true }); }
 	});
 
 	it('contains no raw control-plane paths or removed Market/API runtime terms', () => {


### PR DESCRIPTION
## Summary
- discover durable signed provider registrations that are not yet materialized as connections
- poll pending approvals from the normal manager loop
- exchange the approved one-time authority for durable membership credentials idempotently
- materialize the approved connection without rewriting the canonical packaged manifest
- keep pending approval a healthy, observable manager result

## Verification
- npm run verify:direct
- 21 tests pass
- packed-install verification passes

This supplies the Agent half of the configured capacity-provider bootstrap lifecycle.