### PR TITLE
Hand provider manifests to the runtime user

### DIFF
--- a/compose.capacity-provider.yml
+++ b/compose.capacity-provider.yml
@@ -9,7 +9,8 @@ services:
     restart: unless-stopped
     extra_hosts: ["host.docker.internal:host-gateway"]
     environment: &provider-environment
-      TREESEED_CAPACITY_PROVIDER_MANIFEST: /config/treeseed.capacity-provider.yaml
+      TREESEED_CAPACITY_PROVIDER_SOURCE: /config/treeseed.capacity-provider.yaml
+      TREESEED_CAPACITY_PROVIDER_MANIFEST: /data/config/treeseed.capacity-provider.yaml
       TREESEED_PROVIDER_DATA_DIR: /data
       TREESEED_PROVIDER_ENVIRONMENT: ${TREESEED_PROVIDER_ENVIRONMENT:-local}
       TREESEED_PROVIDER_SOURCE_CLOSURE_DIGEST: ${TREESEED_PROVIDER_SOURCE_CLOSURE_DIGEST:-}

--- a/deploy/compose.template.yml
+++ b/deploy/compose.template.yml
@@ -5,7 +5,8 @@ services:
     command: ["manager"]
     restart: unless-stopped
     environment: &provider-environment
-      TREESEED_CAPACITY_PROVIDER_MANIFEST: /config/treeseed.capacity-provider.yaml
+      TREESEED_CAPACITY_PROVIDER_SOURCE: /config/treeseed.capacity-provider.yaml
+      TREESEED_CAPACITY_PROVIDER_MANIFEST: /data/config/treeseed.capacity-provider.yaml
       TREESEED_PROVIDER_DATA_DIR: /data
       TREESEED_PROVIDER_ENVIRONMENT: managed
       TREESEED_SERVER_PROFILE_LOCAL_URL: ${TREESEED_CONTROL_PLANE_URL:?TREESEED_CONTROL_PLANE_URL is required}

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -7,6 +7,8 @@ APP_GID="${TREESEED_PROVIDER_GID:-65532}"
 CHOWN_DATA="${TREESEED_PROVIDER_CHOWN_DATA:-1}"
 CODEX_AUTH_SOURCE="${TREESEED_CODEX_AUTH_SOURCE:-}"
 CODEX_AUTH_FILE="${TREESEED_CODEX_AUTH_FILE:-$DATA_DIR/credentials/codex-auth.json}"
+MANIFEST_SOURCE="${TREESEED_CAPACITY_PROVIDER_SOURCE:-}"
+MANIFEST_FILE="${TREESEED_CAPACITY_PROVIDER_MANIFEST:-$DATA_DIR/config/treeseed.capacity-provider.yaml}"
 
 if [ "$(id -u)" = "0" ] && [ "${1:-}" = "healthcheck" ]; then
 	exec setpriv --reuid "$APP_UID" --regid "$APP_GID" --clear-groups node ./dist/provider/lifecycle/entrypoint.js "$@"
@@ -17,6 +19,21 @@ mkdir -p "$DATA_DIR"
 if [ "$(id -u)" = "0" ]; then
 	if [ "$CHOWN_DATA" != "0" ]; then
 		chown -R "$APP_UID:$APP_GID" "$DATA_DIR"
+	fi
+	if [ -n "$MANIFEST_SOURCE" ]; then
+		if [ ! -f "$MANIFEST_SOURCE" ] || [ -L "$MANIFEST_SOURCE" ]; then
+			echo "Capacity-provider manifest source must be a regular, non-symlink file." >&2
+			exit 78
+		fi
+		case "$MANIFEST_FILE" in
+			"$DATA_DIR"/config/*) ;;
+			*) echo "Capacity-provider manifest target must remain in the provider configuration directory." >&2; exit 78 ;;
+		esac
+		mkdir -p "$(dirname "$MANIFEST_FILE")"
+		cp "$MANIFEST_SOURCE" "$MANIFEST_FILE"
+		chmod 0600 "$MANIFEST_FILE"
+		chown "$APP_UID:$APP_GID" "$MANIFEST_FILE"
+		export TREESEED_CAPACITY_PROVIDER_MANIFEST="$MANIFEST_FILE"
 	fi
 	if [ -n "$CODEX_AUTH_SOURCE" ]; then
 		if [ ! -f "$CODEX_AUTH_SOURCE" ] || [ -L "$CODEX_AUTH_SOURCE" ]; then

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@treeseed/agent",
-  "version": "0.13.0-rc.15",
+  "version": "0.13.0-rc.16",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@treeseed/agent",
-      "version": "0.13.0-rc.15",
+      "version": "0.13.0-rc.16",
       "license": "Apache-2.0",
       "dependencies": {
         "@openai/codex": "0.149.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@treeseed/agent",
-  "version": "0.13.0-rc.15",
+  "version": "0.13.0-rc.16",
   "description": "Treeseed agent service runtime package.",
   "license": "Apache-2.0",
   "repository": {

--- a/tests/modern/release-publication.test.ts
+++ b/tests/modern/release-publication.test.ts
@@ -50,8 +50,12 @@ describe('Agent RC publication', () => {
 		expect(packageJson.dependencies['@openai/codex']).toBe('0.149.0');
 		expect(dockerfile).toContain('/app/node_modules/@openai/codex/bin/codex.js');
 		expect(entrypoint).toContain('Codex authentication source must be a regular, non-symlink file.');
+		expect(entrypoint).toContain('Capacity-provider manifest source must be a regular, non-symlink file.');
+		expect(entrypoint).toContain('export TREESEED_CAPACITY_PROVIDER_MANIFEST="$MANIFEST_FILE"');
 		expect(entrypoint).toContain('[ "${1:-}" = "healthcheck" ]');
 		expect(compose).toContain('/etc/treeseed/credentials/agent-codex-auth');
+		expect(compose).toContain('TREESEED_CAPACITY_PROVIDER_SOURCE: /config/treeseed.capacity-provider.yaml');
+		expect(compose).toContain('TREESEED_CAPACITY_PROVIDER_MANIFEST: /data/config/treeseed.capacity-provider.yaml');
 		expect(compose).toContain('TREESEED_CODEX_AUTH_FILE: /data/credentials/codex-auth.json');
 		expect(workflow).toContain('codex-cli 0.149.0');
 	});


### PR DESCRIPTION
Closes #34

- validate the root-mounted provider manifest
- copy it into manager-owned provider state with mode 0600
- hand ownership to the unprivileged runtime uid
- use the private copy in standalone and managed Compose bundles
- bump Agent to RC16

Verification: `npm run verify:direct` (21 tests plus packed-install verification).