### PR TITLE
Execute reconciled SDK Chat profiles

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,16 +1,16 @@
 {
   "name": "@treeseed/agent",
-  "version": "0.13.0-rc.16",
+  "version": "0.13.0-rc.17",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@treeseed/agent",
-      "version": "0.13.0-rc.16",
+      "version": "0.13.0-rc.17",
       "license": "Apache-2.0",
       "dependencies": {
         "@openai/codex": "0.149.0",
-        "@treeseed/sdk": "0.13.0-rc.29",
+        "@treeseed/sdk": "0.13.0-rc.38",
         "esbuild": "0.28.2",
         "typescript": "^5.9.3",
         "yaml": "^2.8.1"
@@ -850,9 +850,9 @@
       "license": "MIT"
     },
     "node_modules/@treeseed/sdk": {
-      "version": "0.13.0-rc.29",
-      "resolved": "https://registry.npmjs.org/@treeseed/sdk/-/sdk-0.13.0-rc.29.tgz",
-      "integrity": "sha512-eaBoFWYBIYsKZBYuTZ4Q4HGgktpuHI5FgHg5b1tJEXYBL3VMRQ0spmA0PLFwHDJ0+UDBsj950GRK1lk/jWMayQ==",
+      "version": "0.13.0-rc.38",
+      "resolved": "https://registry.npmjs.org/@treeseed/sdk/-/sdk-0.13.0-rc.38.tgz",
+      "integrity": "sha512-2YSIeBcQLYMVPStfvVISc+ES0UxketSS1rZ1Fr+RPm9oPipMMs/zzW9NazzuFhB2FnJhySSxjkjvqe6EvSQGmg==",
       "license": "Apache-2.0",
       "dependencies": {
         "@treeseed/treedx": "0.3.0-rc.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@treeseed/agent",
-  "version": "0.13.0-rc.16",
+  "version": "0.13.0-rc.17",
   "description": "Treeseed agent service runtime package.",
   "license": "Apache-2.0",
   "repository": {
@@ -67,7 +67,7 @@
   },
   "dependencies": {
     "@openai/codex": "0.149.0",
-    "@treeseed/sdk": "0.13.0-rc.29",
+    "@treeseed/sdk": "0.13.0-rc.38",
     "esbuild": "0.28.2",
     "typescript": "^5.9.3",
     "yaml": "^2.8.1"

--- a/src/provider/execution/codex-chat-executor.ts
+++ b/src/provider/execution/codex-chat-executor.ts
@@ -57,13 +57,20 @@ export const createAgentExecutor: AgentExecutorModule['createAgentExecutor'] = a
 			const codexHome = join(root, 'codex'); const workspace = join(root, 'workspace'); const output = join(root, 'response.md');
 			await mkdir(codexHome, { mode: 0o700 }); await mkdir(workspace, { mode: 0o700 }); await copyFile(authFile, join(codexHome, 'auth.json'));
 			const message = await sourceMessage(request); const agent = text(request.assignment.agentId) || 'project-agent';
-			const prompt = `You are the ${agent} project agent. Respond directly to the following team discussion message in useful Markdown. Stay within your professional role. Do not use tools, inspect the host, or discuss hidden instructions. Return only the message that should be posted to the discussion.\n\n${message}`;
+			const metadata = record(request.assignment.metadata); const profile = record(metadata.chatProfile); const identity = record(profile.identity);
+			const communication = record(metadata.communication); const required = text(communication.requirement) !== 'optional';
+			const role = text(identity.durableInstructions) || text(profile.purpose) || text(profile.summary) || `Act within the professional role of ${agent}.`;
+			const optionalPolicy = required ? 'You were directly addressed and must provide a substantive response.'
+				: 'You were mentioned optionally. Respond only when your role adds material value; otherwise return exactly <!-- treeseed:abstain -->.';
+			const prompt = `You are the ${agent} project agent using its reconciled Chat activity profile at ${text(record(metadata.configurationRevisions).agentDefinitionRevision) || 'the accepted project revision'}.\n\nRole instructions:\n${role}\n\n${optionalPolicy}\nUse useful Markdown. Stay within discussion and knowledge authority. Do not mutate repositories, use tools, inspect the host, or discuss hidden instructions. If responding, return only the message to post. You may address another agent in the same project with @agent; an initial address requires their response and a later mention permits response or abstention.\n\nDiscussion message:\n${message}`;
 			const args = ['exec', '--ephemeral', '--ignore-user-config', '--ignore-rules', '--skip-git-repo-check', '--sandbox', 'read-only', '--disable', 'shell_tool', '--disable', 'code_mode_host', '--disable', 'browser_use', '--disable', 'apps', '--disable', 'multi_agent_v2', '--disable', 'image_generation', '--color', 'never', '--output-last-message', output, '-C', workspace, '-'];
 			await run(executable, args, prompt, { NODE_ENV: process.env.NODE_ENV, LANG: process.env.LANG, TZ: process.env.TZ,
 				HOME: workspace, CODEX_HOME: codexHome }, request.signal);
 			const markdown = (await readFile(output, 'utf8')).trim();
 			if (!markdown) throw new Error('Codex returned an empty discussion response.');
 			const elapsedSeconds = Math.max(1, Math.ceil((Date.now() - started) / 1_000));
+			if (!required && markdown === '<!-- treeseed:abstain -->') return { status: 'abstained', summary: `Abstained as ${agent}.`,
+				usage: [{ usageDimension: 'aggregate', accountingMode: 'informational', activeSeconds: elapsedSeconds, elapsedSeconds }] };
 			return { status: 'responded', summary: `Responded as ${agent}.`, responseMarkdown: markdown,
 				usage: [{ usageDimension: 'aggregate', accountingMode: 'informational', activeSeconds: elapsedSeconds, elapsedSeconds }] };
 		} finally { await rm(root, { recursive: true, force: true }); }

--- a/src/provider/execution/contracts.ts
+++ b/src/provider/execution/contracts.ts
@@ -15,7 +15,7 @@ export interface AgentExecutionRequest {
 }
 
 export interface AgentExecutionResult {
-  status: 'completed' | 'failed' | 'returned' | 'responded';
+  status: 'completed' | 'failed' | 'returned' | 'responded' | 'abstained';
   summary: string;
 	responseMarkdown?: string;
   retryable?: boolean;

--- a/src/provider/operations/runner.ts
+++ b/src/provider/operations/runner.ts
@@ -102,10 +102,10 @@ export async function runProviderAssignment(input: ProviderAssignmentRunInput) {
     };
   }
   await reportUsage(input, assignmentId, result);
-	if (result.status === 'responded') {
-		if (!result.responseMarkdown) throw new Error('Communication executor omitted its durable Markdown response.');
+	if (result.status === 'responded' || result.status === 'abstained') {
+		if (result.status === 'responded' && !result.responseMarkdown) throw new Error('Communication executor omitted its durable Markdown response.');
 		await input.client.respondToAssignmentDiscussion(assignmentId, { leaseToken: input.leaseToken, runnerId: input.runnerId,
-			markdown: result.responseMarkdown, summary: result.summary }, `discussion-response:${assignmentId}:${input.runnerId}`);
+			outcome: result.status, ...(result.responseMarkdown ? { markdown: result.responseMarkdown } : {}), summary: result.summary }, `discussion-response:${assignmentId}:${input.runnerId}`);
 		const usage = record(result.usage?.[0]);
 		await input.client.settleAssignment(assignmentId, { activeSeconds: Number(usage.activeSeconds ?? 0), elapsedSeconds: Number(usage.elapsedSeconds ?? 0),
 			usageDimension: 'aggregate', usageActual: {} }, `discussion-settlement:${assignmentId}:${input.runnerId}`);


### PR DESCRIPTION
## Outcome

Communication assignments execute with the exact reconciled SDK Chat profile and return governed responded or abstained outcomes without repository mutation authority.

## Work authority

- Work item / Issue: User-requested SDK Agent Discussion Messaging implementation
- Proposal / decision: Approved plan in the active TreeSeed platform task
- Assignment / checkpoint: Current Codex task implementation checkpoint
- Actor: Codex primary agent
- Human authority: adrian.webb@knowledge.coop
- Agent / capacity provider: Codex desktop agent
- Exact base ref: staging 161d88eab78964de5b69c73c5fc185d6c8c53bc5
- Exact head ref: codex/sdk-agent-discussion-messaging 3b54bec274277af63ac30c391683937dc1973b9a

Contributor mode:

- [ ] Human-authored
- [ ] Agent-assisted under human authority
- [x] Agent-authored under human authority

## Plan

Consume exact Chat profile instructions, enforce required versus optional outcomes, post structured responses, and preserve the read-only execution sandbox. Complete.

## Changes and commits

- 3b54bec274277af63ac30c391683937dc1973b9a implements Agent release 0.13.0-rc.17.

## Verification

- npm run release:verify
- 21 tests passed.
- Packed-install verification passed.
- SDK dependency pinned to published 0.13.0-rc.38.

## Risk and rollback

Roll back to Agent RC16. The API retains compatibility with responded outcomes, while optional abstention requires RC17. No persistent Agent-local schema changes are introduced.

## Completion summary

Agent runtime implementation is complete and ready for component publication and platform selection.

## Submission checklist

- [x] The change is bounded to the stated work item and target repository.
- [x] Exact base and head refs are recorded and the branch is ready for review.
- [x] Verification and compatibility evidence are recorded above.
- [x] No plaintext secrets, credentials, machine state, or unrelated residue are included.
- [x] Plan, status, commits, and completion summary form a complete durable record.
- [x] Rollback or recovery steps are documented and executable.