### PR TITLE
fix(provider): send execution start evidence

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@treeseed/agent",
-  "version": "0.13.0-rc.19",
+  "version": "0.13.0-rc.20",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@treeseed/agent",
-      "version": "0.13.0-rc.19",
+      "version": "0.13.0-rc.20",
       "license": "Apache-2.0",
       "dependencies": {
         "@openai/codex": "0.149.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@treeseed/agent",
-  "version": "0.13.0-rc.19",
+  "version": "0.13.0-rc.20",
   "description": "Treeseed agent service runtime package.",
   "license": "Apache-2.0",
   "repository": {

--- a/src/provider/operations/runner.ts
+++ b/src/provider/operations/runner.ts
@@ -42,7 +42,16 @@ async function reportUsage(input: ProviderAssignmentRunInput, assignmentId: stri
 export async function runProviderAssignment(input: ProviderAssignmentRunInput) {
   const assignmentId = text(input.assignment.id);
   if (!assignmentId) throw new Error('Catalogued assignment lease omitted its stable id.');
-  await input.client.startAssignmentExecution(assignmentId, { leaseToken: input.leaseToken, runnerId: input.runnerId, executorId: input.executor.id });
+  const metadata = record(input.assignment.metadata);
+  const contentRoot = text(metadata.contentRoot) || '.';
+  await input.client.startAssignmentExecution(assignmentId, {
+    leaseToken: input.leaseToken,
+    runnerId: input.runnerId,
+    executorId: input.executor.id,
+    idempotencyKey: `execution-start:${assignmentId}:${input.runnerId}`,
+    expectedStateVersion: Number(input.assignment.stateVersion),
+    planRef: { id: `assignment-plan:${assignmentId}`, path: `${contentRoot}/assignment-plans/${assignmentId}.mdx` },
+  });
   let result: AgentExecutionResult;
   let stopped = false;
   let renewalFailure: unknown = null;

--- a/tests/modern/provider-runner.test.ts
+++ b/tests/modern/provider-runner.test.ts
@@ -35,12 +35,16 @@ describe('catalog-driven provider assignment runner', () => {
 		await runProviderAssignment({
 			client: api,
 			executor,
-			assignment: { id: 'assignment-1' },
+			assignment: { id: 'assignment-1', stateVersion: 2, metadata: { contentRoot: '.' } },
 			treeDx,
 			leaseToken: 'lease',
 			runnerId: 'runner',
 		});
-		expect(api.startAssignmentExecution).toHaveBeenCalledWith('assignment-1', expect.objectContaining({ executorId: 'fake' }));
+		expect(api.startAssignmentExecution).toHaveBeenCalledWith('assignment-1', expect.objectContaining({
+			executorId: 'fake', expectedStateVersion: 2,
+			idempotencyKey: 'execution-start:assignment-1:runner',
+			planRef: { id: 'assignment-plan:assignment-1', path: './assignment-plans/assignment-1.mdx' },
+		}));
 		expect(api.reportAssignmentUsage).toHaveBeenCalledOnce();
 		expect(api.startAssignmentCloseout).toHaveBeenCalledOnce();
 		expect(api.preflightAssignmentCompletion).toHaveBeenCalledOnce();


### PR DESCRIPTION
## Outcome
Send deterministic idempotency, state-version, and assignment-plan evidence when starting provider execution.

## Work authority
- Work item / Issue: SDK Agent Discussion Messaging live acceptance
- Proposal / decision: Align Agent runner with execution-start contract
- Assignment / checkpoint: Execute leased SDK Chat assignment
- Actor: Codex under Adrian Webb authority
- Human authority: Adrian Webb
- Agent / capacity provider: SDK Architect / codex-local
- Exact base ref: 067676f6ce196c03eff028f28817ed429df018f9
- Exact head ref: 03fdfe800436356faea4502e941805bd50b3da20

## Plan
Publish Agent rc20, update host, execute fresh send.

## Changes and commits
Builds exact plan id/path from assignment id and content root, includes state version and idempotency key; adds exact request test.

## Verification
- `npm run release:verify`: 6 files / 23 tests plus packed install.
- Live leased assignment failed at execution-start evidence validation.

## Risk and rollback
Bounded protocol payload addition; recover via later reviewed Agent release.

## Completion summary
Leased Chat assignments can enter productive execution.

## Submission checklist
- [x] Agent-authored under human authority
- [x] The change is bounded to the stated work item and target repository.
- [x] Exact base and head refs are recorded and the branch is ready for review.
- [x] Verification and compatibility evidence are recorded above.
- [x] No plaintext secrets, credentials, machine state, or unrelated residue are included.
- [x] Plan, status, commits, and completion summary form a complete durable record.
- [x] Rollback or recovery steps are documented and executable.