### PR TITLE
fix(agent): accept root discussion message refs

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@treeseed/agent",
-  "version": "0.13.0-rc.20",
+  "version": "0.13.0-rc.21",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@treeseed/agent",
-      "version": "0.13.0-rc.20",
+      "version": "0.13.0-rc.21",
       "license": "Apache-2.0",
       "dependencies": {
         "@openai/codex": "0.149.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@treeseed/agent",
-  "version": "0.13.0-rc.20",
+  "version": "0.13.0-rc.21",
   "description": "Treeseed agent service runtime package.",
   "license": "Apache-2.0",
   "repository": {

--- a/src/provider/execution/codex-chat-executor.ts
+++ b/src/provider/execution/codex-chat-executor.ts
@@ -7,13 +7,14 @@ import type { AgentExecutionRequest, AgentExecutorModule } from './contracts.ts'
 const record = (value: unknown): Record<string, unknown> => value && typeof value === 'object' && !Array.isArray(value) ? value as Record<string, unknown> : {};
 const text = (value: unknown) => typeof value === 'string' ? value.trim() : '';
 
-function sourcePaths(assignment: Record<string, unknown>) {
+export function discussionMessageSourcePaths(assignment: Record<string, unknown>) {
 	return Array.isArray(assignment.sourceMessageRefs)
-		? assignment.sourceMessageRefs.map(String).filter((value) => value.includes('/discussion-messages/')) : [];
+		? assignment.sourceMessageRefs.map(String).map((value) => value.replaceAll('\\', '/').replace(/^\.\//, ''))
+			.filter((value) => value.startsWith('discussion-messages/') || value.includes('/discussion-messages/')) : [];
 }
 
 async function sourceMessage(request: AgentExecutionRequest) {
-	const repoId = request.treeDx.repositoryId; const paths = sourcePaths(request.assignment);
+	const repoId = request.treeDx.repositoryId; const paths = discussionMessageSourcePaths(request.assignment);
 	if (!repoId || !paths.length) throw new Error('Communication assignment omitted its TreeDX source message reference.');
 	const envelope = record(await request.treeDx.invoke('treedx.repositories.files.read', {
 		path: { repoId }, body: { paths: [paths[0]], encoding: 'utf8', parseFrontmatter: true, allowProtected: true },

--- a/tests/modern/codex-chat-executor.test.ts
+++ b/tests/modern/codex-chat-executor.test.ts
@@ -1,0 +1,17 @@
+import { describe, expect, it } from 'vitest';
+import { discussionMessageSourcePaths } from '../../src/provider/execution/codex-chat-executor.ts';
+
+describe('Codex chat executor', () => {
+	it('accepts root and nested TreeDX discussion-message references', () => {
+		expect(discussionMessageSourcePaths({ sourceMessageRefs: [
+			'discussion-messages/topic/message.mdx',
+			'./discussion-messages/topic/second.mdx',
+			'src/content/discussion-messages/topic/legacy.mdx',
+			'knowledge/topic/message.mdx',
+		] })).toEqual([
+			'discussion-messages/topic/message.mdx',
+			'discussion-messages/topic/second.mdx',
+			'src/content/discussion-messages/topic/legacy.mdx',
+		]);
+	});
+});


### PR DESCRIPTION
## Outcome

Allow the Chat executor to consume discussion messages stored at the repository root after the library migration.

## Work authority

- Work item / Issue: SDK agent discussion messaging live acceptance
- Proposal / decision: accept normalized root-level and nested discussion-message references
- Assignment / checkpoint: live @architect send failed at source-message resolution
- Actor: Codex under Adrian Webb authority
- Human authority: Adrian Webb
- Agent / capacity provider: codex-local communication provider
- Exact base ref: ac5652cd1eb246ccd1e2357f1e8bcff1330c290e
- Exact head ref: 59d56340c67b1f8b612ce486d9c5655413e4aac0

## Plan

Normalize TreeDX paths, accept the canonical root collection, retain legacy nested compatibility, and publish rc21.

## Changes and commits

- `59d5634` fixes source-reference matching and adds focused regression coverage.
- Bumps `@treeseed/agent` to `0.13.0-rc.21`.

## Verification

`npm run release:verify` passed: 7 files, 24 tests, build, pack, and packed-install verification.

## Risk and rollback

The matcher remains limited to the `discussion-messages` collection. Roll back by restoring Agent rc20 in the governed Platform/Deployment lock if live verification regresses.

## Completion summary

Root-level library discussion-message refs now reach the Chat executor TreeDX read path.

## Submission checklist

- [x] Agent-authored under human authority
- [x] The change is bounded to the stated work item and target repository.
- [x] Exact base and head refs are recorded and the branch is ready for review.
- [x] Verification and compatibility evidence are recorded above.
- [x] No plaintext secrets, credentials, machine state, or unrelated residue are included.
- [x] Plan, status, commits, and completion summary form a complete durable record.
- [x] Rollback or recovery steps are documented and executable.