### PR TITLE
fix(agent): read chat source at exact ref

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@treeseed/agent",
-  "version": "0.13.0-rc.21",
+  "version": "0.13.0-rc.22",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@treeseed/agent",
-      "version": "0.13.0-rc.21",
+      "version": "0.13.0-rc.22",
       "license": "Apache-2.0",
       "dependencies": {
         "@openai/codex": "0.149.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@treeseed/agent",
-  "version": "0.13.0-rc.21",
+  "version": "0.13.0-rc.22",
   "description": "Treeseed agent service runtime package.",
   "license": "Apache-2.0",
   "repository": {

--- a/src/provider/coordination/assignment-treedx.ts
+++ b/src/provider/coordination/assignment-treedx.ts
@@ -31,6 +31,7 @@ export async function createAssignmentTreeDxFacade(connection: ProviderControlPl
 	}));
 	return {
 		projectId, repositoryId: text(handle.repositoryId) || null, workspaceId: text(handle.workspaceId) || null,
+		baseRef: text(handle.baseRef, handle.baseCommitSha) || null,
 		async invoke(operationId, input, options = {}) {
 			const operation = operations.get(operationId);
 			if (!operation) throw new Error(`TreeDX proxy operation ${operationId} is not part of the accepted SDK catalog.`);

--- a/src/provider/execution/codex-chat-executor.ts
+++ b/src/provider/execution/codex-chat-executor.ts
@@ -13,11 +13,12 @@ export function discussionMessageSourcePaths(assignment: Record<string, unknown>
 			.filter((value) => value.startsWith('discussion-messages/') || value.includes('/discussion-messages/')) : [];
 }
 
-async function sourceMessage(request: AgentExecutionRequest) {
+export async function readDiscussionSourceMessage(request: AgentExecutionRequest) {
 	const repoId = request.treeDx.repositoryId; const paths = discussionMessageSourcePaths(request.assignment);
 	if (!repoId || !paths.length) throw new Error('Communication assignment omitted its TreeDX source message reference.');
 	const envelope = record(await request.treeDx.invoke('treedx.repositories.files.read', {
-		path: { repoId }, body: { paths: [paths[0]], encoding: 'utf8', parseFrontmatter: true, allowProtected: true },
+		path: { repoId }, body: { ...(request.treeDx.baseRef ? { ref: request.treeDx.baseRef } : {}),
+			paths: [paths[0]], encoding: 'utf8', parseFrontmatter: true, allowProtected: true },
 	}));
 	const data = record(envelope.data); const files = Array.isArray(data.files) ? data.files.map(record) : [];
 	const content = text(files[0]?.content) || text(files[0]?.body);
@@ -57,7 +58,7 @@ export const createAgentExecutor: AgentExecutorModule['createAgentExecutor'] = a
 		try {
 			const codexHome = join(root, 'codex'); const workspace = join(root, 'workspace'); const output = join(root, 'response.md');
 			await mkdir(codexHome, { mode: 0o700 }); await mkdir(workspace, { mode: 0o700 }); await copyFile(authFile, join(codexHome, 'auth.json'));
-			const message = await sourceMessage(request); const agent = text(request.assignment.agentId) || 'project-agent';
+			const message = await readDiscussionSourceMessage(request); const agent = text(request.assignment.agentId) || 'project-agent';
 			const metadata = record(request.assignment.metadata); const profile = record(metadata.chatProfile); const identity = record(profile.identity);
 			const communication = record(metadata.communication); const required = text(communication.requirement) !== 'optional';
 			const role = text(identity.durableInstructions) || text(profile.purpose) || text(profile.summary) || `Act within the professional role of ${agent}.`;

--- a/src/provider/execution/contracts.ts
+++ b/src/provider/execution/contracts.ts
@@ -2,6 +2,7 @@ export interface AssignmentTreeDxFacade {
   readonly projectId: string;
   readonly repositoryId: string | null;
   readonly workspaceId: string | null;
+  readonly baseRef?: string | null;
   invoke(operationId: string, input: Record<string, unknown>, options?: { signal?: AbortSignal; idempotencyKey?: string }): Promise<unknown>;
 }
 

--- a/src/provider/execution/process-executor-worker.ts
+++ b/src/provider/execution/process-executor-worker.ts
@@ -18,7 +18,8 @@ async function initialize(message: any) {
 
 function treeDx(requestId: string, snapshot: any): AssignmentTreeDxFacade {
 	return {
-		projectId: String(snapshot.projectId), repositoryId: snapshot.repositoryId ?? null, workspaceId: snapshot.workspaceId ?? null,
+		projectId: String(snapshot.projectId), repositoryId: snapshot.repositoryId ?? null,
+		workspaceId: snapshot.workspaceId ?? null, baseRef: snapshot.baseRef ?? null,
 		invoke(operationId, input, options) {
 			return new Promise((resolve, reject) => {
 				const callId = `${requestId}:${++callSequence}`;

--- a/src/provider/execution/process-executor.ts
+++ b/src/provider/execution/process-executor.ts
@@ -55,7 +55,8 @@ export function createProcessIsolatedExecutor(config: ProviderHostRuntimeConfig,
 		const id = `${adapter.id}:${++sequence}`;
 		pending.set(id, { resolve: resolve as (value: unknown) => void, reject, request: value });
 		child.send({ type, id, request: value ? { assignment: value.assignment, assignmentId: value.assignmentId, leaseToken: value.leaseToken, runnerId: value.runnerId,
-			treeDx: { projectId: value.treeDx.projectId, repositoryId: value.treeDx.repositoryId, workspaceId: value.treeDx.workspaceId } } : undefined });
+			treeDx: { projectId: value.treeDx.projectId, repositoryId: value.treeDx.repositoryId,
+				workspaceId: value.treeDx.workspaceId, baseRef: value.treeDx.baseRef } } : undefined });
 		if (value?.signal) value.signal.addEventListener('abort', () => child.send({ type: 'cancel', id }), { once: true });
 	});
 	child.send({ type: 'initialize', module, executionProviderId: adapter.id, environment: config.environment });

--- a/tests/modern/assignment-treedx.test.ts
+++ b/tests/modern/assignment-treedx.test.ts
@@ -13,8 +13,9 @@ describe('assignment-scoped TreeDX facade', () => {
 			controlPlaneUrl: 'https://api.example.test', accessToken: 'provider-token',
 		}, {
 			id: 'assignment-1', projectId: 'project-1',
-			treedxProxyHandle: { id: 'handle-1', token: 'handle-token', repositoryId: 'repo-1', workspaceId: 'workspace-1' },
+			treedxProxyHandle: { id: 'handle-1', token: 'handle-token', repositoryId: 'repo-1', workspaceId: 'workspace-1', baseRef: 'commit-1' },
 		});
+		expect(facade.baseRef).toBe('commit-1');
 		await facade.invoke('treedx.workspaces.show', { path: { projectId: 'other-project', workspaceId: 'workspace-1' }, query: {}, body: undefined });
 		const [request, init] = fetchImpl.mock.calls[0]!;
 		expect(String(request)).toBe('https://api.example.test/v1/dx/projects/project-1/workspaces/workspace-1');

--- a/tests/modern/codex-chat-executor.test.ts
+++ b/tests/modern/codex-chat-executor.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { discussionMessageSourcePaths } from '../../src/provider/execution/codex-chat-executor.ts';
+import { discussionMessageSourcePaths, readDiscussionSourceMessage } from '../../src/provider/execution/codex-chat-executor.ts';
 
 describe('Codex chat executor', () => {
 	it('accepts root and nested TreeDX discussion-message references', () => {
@@ -13,5 +13,19 @@ describe('Codex chat executor', () => {
 			'discussion-messages/topic/second.mdx',
 			'src/content/discussion-messages/topic/legacy.mdx',
 		]);
+	});
+
+	it('reads the committed discussion message at the assignment exact ref', async () => {
+		let input: Record<string, unknown> | undefined;
+		const content = await readDiscussionSourceMessage({
+			assignment: { sourceMessageRefs: ['discussion-messages/topic/message.mdx'] },
+			assignmentId: 'assignment-1', leaseToken: 'lease', runnerId: 'runner',
+			treeDx: { projectId: 'project-1', repositoryId: 'repo-1', workspaceId: 'workspace-1', baseRef: 'commit-1',
+				invoke: async (_operationId, value) => { input = value; return { data: { files: [{ content: 'Exact message' }] } }; } },
+		});
+		expect(content).toBe('Exact message');
+		expect(input).toEqual({ path: { repoId: 'repo-1' }, body: {
+			ref: 'commit-1', paths: ['discussion-messages/topic/message.mdx'], encoding: 'utf8', parseFrontmatter: true, allowProtected: true,
+		} });
 	});
 });


### PR DESCRIPTION
## Outcome

Read committed discussion messages at the exact TreeDX ref issued with the assignment.

## Work authority

- Work item / Issue: SDK agent discussion messaging live acceptance
- Proposal / decision: carry the scoped base ref through the executor facade
- Assignment / checkpoint: live rc34 send reached TreeDX but default-head read returned not found
- Actor: Codex under Adrian Webb authority
- Human authority: Adrian Webb
- Agent / capacity provider: codex-local communication provider
- Exact base ref: 3fe5bea9761f949506a18d2dda0317dc8d00637f
- Exact head ref: 885318da025e89a813fa58b70edb5f181a6650ea

## Plan

Expose the already-issued base ref, preserve it across isolated execution, and include it in the repository read.

## Changes and commits

- `885318d` adds exact-ref source reads and Agent `0.13.0-rc.22`.

## Verification

`npm run release:verify` passed 7 files / 25 tests, build, pack, and packed-install verification. Live diagnosis confirmed the message exists at the issued commit and is absent from the canonical SDK library head by design.

## Risk and rollback

The read remains limited by the assignment proxy path scope and exact immutable ref. Roll back by selecting Agent rc21 in a new generation.

## Completion summary

Chat execution now reads the same immutable discussion commit recorded in its invocation receipt.

## Submission checklist

- [x] Agent-authored under human authority
- [x] The change is bounded to the stated work item and target repository.
- [x] Exact base and head refs are recorded and the branch is ready for review.
- [x] Verification and compatibility evidence are recorded above.
- [x] No plaintext secrets, credentials, machine state, or unrelated residue are included.
- [x] Plan, status, commits, and completion summary form a complete durable record.
- [x] Rollback or recovery steps are documented and executable.