### PR TITLE
fix(agent): unwrap TreeDX proxy results

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@treeseed/agent",
-  "version": "0.13.0-rc.22",
+  "version": "0.13.0-rc.23",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@treeseed/agent",
-      "version": "0.13.0-rc.22",
+      "version": "0.13.0-rc.23",
       "license": "Apache-2.0",
       "dependencies": {
         "@openai/codex": "0.149.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@treeseed/agent",
-  "version": "0.13.0-rc.22",
+  "version": "0.13.0-rc.23",
   "description": "Treeseed agent service runtime package.",
   "license": "Apache-2.0",
   "repository": {

--- a/src/provider/execution/codex-chat-executor.ts
+++ b/src/provider/execution/codex-chat-executor.ts
@@ -20,7 +20,8 @@ export async function readDiscussionSourceMessage(request: AgentExecutionRequest
 		path: { repoId }, body: { ...(request.treeDx.baseRef ? { ref: request.treeDx.baseRef } : {}),
 			paths: [paths[0]], encoding: 'utf8', parseFrontmatter: true, allowProtected: true },
 	}));
-	const data = record(envelope.data); const files = Array.isArray(data.files) ? data.files.map(record) : [];
+	const data = record(envelope.data ?? envelope); const result = record(data.result ?? data);
+	const payload = record(result.data ?? result); const files = Array.isArray(payload.files) ? payload.files.map(record) : [];
 	const content = text(files[0]?.content) || text(files[0]?.body);
 	if (!content) throw new Error('TreeDX did not return the assignment source message.');
 	return content;

--- a/tests/modern/codex-chat-executor.test.ts
+++ b/tests/modern/codex-chat-executor.test.ts
@@ -21,7 +21,9 @@ describe('Codex chat executor', () => {
 			assignment: { sourceMessageRefs: ['discussion-messages/topic/message.mdx'] },
 			assignmentId: 'assignment-1', leaseToken: 'lease', runnerId: 'runner',
 			treeDx: { projectId: 'project-1', repositoryId: 'repo-1', workspaceId: 'workspace-1', baseRef: 'commit-1',
-				invoke: async (_operationId, value) => { input = value; return { data: { files: [{ content: 'Exact message' }] } }; } },
+				invoke: async (_operationId, value) => { input = value; return {
+					data: { result: { files: [{ content: 'Exact message' }] }, receipt: { requestId: 'request-1' } },
+				}; } },
 		});
 		expect(content).toBe('Exact message');
 		expect(input).toEqual({ path: { repoId: 'repo-1' }, body: {


### PR DESCRIPTION
## Outcome

Parse the documented control-plane TreeDX proxy result envelope before reading source files.

## Work authority

- Work item / Issue: SDK agent discussion messaging live acceptance
- Proposal / decision: normalize accepted direct and proxied TreeDX payload shapes
- Assignment / checkpoint: rc22 exact-ref read succeeded but source content was hidden under `data.result`
- Actor: Codex under Adrian Webb authority
- Human authority: Adrian Webb
- Agent / capacity provider: codex-local communication provider
- Exact base ref: 2427ebf86eba4ca5d9a937eebbe20210a1df0f14
- Exact head ref: 63c713887a691af92962f5d8f32649cb7592835f

## Plan

Unwrap the SDK response envelope, proxy result, and upstream data without accepting arbitrary scalar shapes.

## Changes and commits

- `63c7138` normalizes proxy results, updates regression coverage, and bumps Agent rc23.

## Verification

`npm run release:verify` passed 7 files / 25 tests, build, pack, and packed-install verification.

## Risk and rollback

Normalization is read-only and limited to documented object envelopes. Roll back via a new governed generation selecting rc22.

## Completion summary

The Chat executor can consume the exact-ref file payload returned by the control-plane TreeDX proxy.

## Submission checklist

- [x] Agent-authored under human authority
- [x] The change is bounded to the stated work item and target repository.
- [x] Exact base and head refs are recorded and the branch is ready for review.
- [x] Verification and compatibility evidence are recorded above.
- [x] No plaintext secrets, credentials, machine state, or unrelated residue are included.
- [x] Plan, status, commits, and completion summary form a complete durable record.
- [x] Rollback or recovery steps are documented and executable.