### PR TITLE
fix(agent): settle chat usage terminally

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@treeseed/agent",
-  "version": "0.13.0-rc.23",
+  "version": "0.13.0-rc.24",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@treeseed/agent",
-      "version": "0.13.0-rc.23",
+      "version": "0.13.0-rc.24",
       "license": "Apache-2.0",
       "dependencies": {
         "@openai/codex": "0.149.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@treeseed/agent",
-  "version": "0.13.0-rc.23",
+  "version": "0.13.0-rc.24",
   "description": "Treeseed agent service runtime package.",
   "license": "Apache-2.0",
   "repository": {

--- a/src/provider/operations/runner.ts
+++ b/src/provider/operations/runner.ts
@@ -110,7 +110,6 @@ export async function runProviderAssignment(input: ProviderAssignmentRunInput) {
       retryable: true,
     };
   }
-  await reportUsage(input, assignmentId, result);
 	if (result.status === 'responded' || result.status === 'abstained') {
 		if (result.status === 'responded' && !result.responseMarkdown) throw new Error('Communication executor omitted its durable Markdown response.');
 		await input.client.respondToAssignmentDiscussion(assignmentId, { leaseToken: input.leaseToken, runnerId: input.runnerId,
@@ -120,6 +119,7 @@ export async function runProviderAssignment(input: ProviderAssignmentRunInput) {
 			usageDimension: 'aggregate', usageActual: {} }, `discussion-settlement:${assignmentId}:${input.runnerId}`);
 		return input.client.returnAssignment(assignmentId, { runnerId: input.runnerId, summary: { text: result.summary } });
 	}
+	await reportUsage(input, assignmentId, result);
   if (result.status === 'returned') {
     return input.client.returnAssignment(assignmentId, { leaseToken: input.leaseToken, runnerId: input.runnerId, code: result.code ?? 'agent_executor_returned', reason: result.summary, retryable: result.retryable ?? true });
   }

--- a/tests/modern/provider-runner.test.ts
+++ b/tests/modern/provider-runner.test.ts
@@ -85,6 +85,10 @@ describe('catalog-driven provider assignment runner', () => {
 		await runProviderAssignment({ client: api, treeDx, leaseToken: 'lease', runnerId: 'runner', assignment: { id: 'assignment-chat', executionKind: 'conversation' },
 			executor: { id: 'chat', observe: async () => ({ available: true }), execute: async () => ({ status: 'responded', summary: 'Answered.', responseMarkdown: '## Answer\n\nReady.', usage: [{ activeSeconds: 3, elapsedSeconds: 4 }] }) } });
 		expect(api.respondToAssignmentDiscussion).toHaveBeenCalledWith('assignment-chat', expect.objectContaining({ leaseToken: 'lease', markdown: '## Answer\n\nReady.' }), expect.any(String));
+		expect(api.reportAssignmentUsage).not.toHaveBeenCalled();
+		expect(api.settleAssignment).toHaveBeenCalledWith('assignment-chat', expect.objectContaining({
+			activeSeconds: 3, elapsedSeconds: 4, usageDimension: 'aggregate',
+		}), expect.any(String));
 		expect(api.settleAssignment).toHaveBeenCalledBefore(api.returnAssignment);
 		expect(api.completeAssignment).not.toHaveBeenCalled();
 	});


### PR DESCRIPTION
## Outcome

Settle Chat agent time once at terminal aggregate settlement instead of sending an invalid pre-terminal informational time report.

## Work authority

- Work item / Issue: SDK agent discussion messaging live acceptance
- Proposal / decision: use the existing communication terminal-settlement path exclusively
- Assignment / checkpoint: rc23 model execution reached accounting and was rejected before response commit
- Actor: Codex under Adrian Webb authority
- Human authority: Adrian Webb
- Agent / capacity provider: codex-local communication provider
- Exact base ref: 1494163eb64acc2b1a700056186a9605cda982e8
- Exact head ref: e36be3dbe6d4833c4dfe823f8138953b1658fda3

## Plan

Skip incremental usage reporting for responded/abstained outcomes and assert exact terminal seconds.

## Changes and commits

- `e36be3d` fixes Chat settlement order and bumps Agent rc24.

## Verification

`npm run release:verify` passed 7 files / 25 tests, build, pack, and packed-install verification.

## Risk and rollback

Non-communication assignment usage reporting is unchanged. Roll back via a new generation selecting rc23.

## Completion summary

Chat responses now proceed to durable response commit and exact terminal settlement.

## Submission checklist

- [x] Agent-authored under human authority
- [x] The change is bounded to the stated work item and target repository.
- [x] Exact base and head refs are recorded and the branch is ready for review.
- [x] Verification and compatibility evidence are recorded above.
- [x] No plaintext secrets, credentials, machine state, or unrelated residue are included.
- [x] Plan, status, commits, and completion summary form a complete durable record.
- [x] Rollback or recovery steps are documented and executable.