### PR TITLE
feat: add drain-safe Agent development runtime

### DIFF
--- a/scripts/development/check-drain.mjs
+++ b/scripts/development/check-drain.mjs
@@ -1,0 +1,10 @@
+import { existsSync, readFileSync } from 'node:fs';
+
+const path = process.argv[2];
+if (!path) throw new Error('Capacity state path is required.');
+if (!existsSync(path)) process.exit(0);
+const state = JSON.parse(readFileSync(path, 'utf8'));
+if (!Array.isArray(state.claims) || !Array.isArray(state.connections) || !Array.isArray(state.events)) throw new Error('Provider capacity state is invalid.');
+const active = state.claims.filter((claim) => ['ready', 'running', 'recovery'].includes(claim.status));
+if (active.length) throw new Error(`Provider drain is blocked by ${active.length} active or unsettled assignment claim(s).`);
+process.stdout.write(`${JSON.stringify({ drained: true, activeAssignments: 0, recoveryClaims: 0 })}\n`);

--- a/scripts/development/runtime.sh
+++ b/scripts/development/runtime.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+session_id="${TREESEED_DEVELOPMENT_SESSION_ID:?TREESEED_DEVELOPMENT_SESSION_ID is required}"
+worktree="${TREESEED_DEVELOPMENT_WORKTREE:?TREESEED_DEVELOPMENT_WORKTREE is required}"
+project="treeseed-agent-${session_id//[^a-zA-Z0-9_-]/-}"
+session_root="$worktree/.treeseed/cache/development-sessions/$session_id/provider"
+state_file="$session_root/runtime/capacity-state.json"
+export TREESEED_PROVIDER_HOST_DATA_DIR="$session_root"
+
+compose() {
+  docker compose --file compose.capacity-provider.yml --project-name "$project" "$@"
+}
+
+drain() {
+  compose stop manager >/dev/null 2>&1 || true
+  node scripts/development/check-drain.mjs "$state_file"
+}
+
+case "${1:-}" in
+  rebuild)
+    test -f "${TREESEED_CAPACITY_PROVIDER_MANIFEST:?TREESEED_CAPACITY_PROVIDER_MANIFEST is required}"
+    test -f "${TREESEED_CODEX_AUTH_HOST_FILE:?TREESEED_CODEX_AUTH_HOST_FILE is required}"
+    mkdir -p "$session_root"
+    drain
+    exec docker compose --file compose.capacity-provider.yml --project-name "$project" up --build --remove-orphans
+    ;;
+  drain)
+    drain
+    ;;
+  verify)
+    test "$(compose ps --status running --services | sort | tr '\n' ' ')" = "manager runner "
+    node scripts/development/check-drain.mjs "$state_file"
+    npm run test:provider-runtime
+    ;;
+  cleanup)
+    drain
+    compose down --remove-orphans
+    case "$session_root" in
+      "$worktree/.treeseed/cache/development-sessions/$session_id/provider") rm -rf -- "$session_root" ;;
+      *) printf 'Refusing unsafe provider cleanup path\n' >&2; exit 1 ;;
+    esac
+    ;;
+  *)
+    printf 'usage: %s rebuild|drain|verify|cleanup\n' "$0" >&2
+    exit 2
+    ;;
+esac

--- a/tests/modern/development-runtime.test.ts
+++ b/tests/modern/development-runtime.test.ts
@@ -1,0 +1,31 @@
+import { spawnSync } from 'node:child_process';
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { resolve } from 'node:path';
+import { parse as parseYaml } from 'yaml';
+import { describe, expect, it } from 'vitest';
+
+describe('capacity provider development runtime', () => {
+	it('declares cloned state and drain-gated cleanup', () => {
+		const manifest = parseYaml(readFileSync('treeseed.package.yaml', 'utf8')) as { development: unknown };
+		const runtime = manifest.development as { schemaVersion: string; targets: Array<{ statePolicy: string; shutdown: { activeWorkPolicy: string; drainOperation?: { args: string[] } }; forbiddenOperations: string[] }> };
+		expect(runtime.schemaVersion).toBe('treeseed.development-runtime/v1');
+		const provider = runtime.targets[0]!;
+		expect(provider.statePolicy).toBe('clone');
+		expect(provider.shutdown.activeWorkPolicy).toBe('drain');
+		expect(provider.shutdown.drainOperation?.args).toContain('drain');
+		expect(provider.forbiddenOperations).toContain('force-kill-active-assignment');
+	});
+
+	it('blocks cleanup while an assignment or settlement claim remains', () => {
+		const root = mkdtempSync(resolve(tmpdir(), 'treeseed-agent-drain-')), state = resolve(root, 'capacity-state.json');
+		try {
+			writeFileSync(state, JSON.stringify({ claims: [{ status: 'running' }], connections: [], events: [] }));
+			const blocked = spawnSync(process.execPath, ['scripts/development/check-drain.mjs', state], { encoding: 'utf8' });
+			expect(blocked.status).toBe(1);
+			expect(blocked.stderr).toMatch(/active or unsettled assignment/u);
+			writeFileSync(state, JSON.stringify({ claims: [], connections: [], events: [{ outcome: 'settled' }] }));
+			expect(spawnSync(process.execPath, ['scripts/development/check-drain.mjs', state]).status).toBe(0);
+		} finally { rmSync(root, { recursive: true, force: true }); }
+	});
+});

--- a/treeseed.package.yaml
+++ b/treeseed.package.yaml
@@ -51,18 +51,20 @@ development:
       sourceRoots: [src, Dockerfile, compose.capacity-provider.yml]
       ignoredPaths: [dist, node_modules, .treeseed/local-capacity-providers]
       operations:
-        build: { command: npm, args: [run, capacity-provider:build], environment: {}, timeoutSeconds: 3600 }
-        verify: { command: npm, args: [run, test:provider-runtime], environment: {}, timeoutSeconds: 1800 }
+        build: { command: bash, args: [scripts/development/runtime.sh, rebuild], environment: {}, timeoutSeconds: 86400 }
+        stop: { command: bash, args: [scripts/development/runtime.sh, drain], environment: {}, timeoutSeconds: 300 }
+        verify: { command: bash, args: [scripts/development/runtime.sh, verify], environment: {}, timeoutSeconds: 1800 }
+        cleanup: { command: bash, args: [scripts/development/runtime.sh, cleanup], environment: {}, timeoutSeconds: 300 }
       ready: { kind: process, graceSeconds: 5 }
       outputs: [{ path: dist, mediaType: application/vnd.treeseed.agent-runtime, digestAlgorithm: sha256 }]
       endpoints: []
       dependencies:
         - { id: sdk, target: package, locality: local, reaction: rebuild }
         - { id: api, target: service, capability: control-plane-api, locality: either, reaction: manual }
-      statePolicy: shared-compatible
-      migrationPolicy: explicit-review
+      statePolicy: clone
+      migrationPolicy: disposable-only
       secretRefs: {}
-      shutdown: { graceSeconds: 120, activeWorkPolicy: drain }
+      shutdown: { drainOperation: { command: bash, args: [scripts/development/runtime.sh, drain], environment: {}, timeoutSeconds: 300 }, graceSeconds: 120, activeWorkPolicy: drain }
       resources: {}
       logs: [.treeseed/development/provider.log]
       forbiddenOperations: [hot-reload, force-kill-active-assignment, automatic-assignment-cancel]


### PR DESCRIPTION
## Outcome

Adds a drain-safe, session-scoped Agent provider development runtime.

## Work authority

- Work item / Issue: treeseed-ai/platform#152
- Proposal / decision: docs/dev-release.md accepted implementation plan
- Assignment / checkpoint: treeseed-ai/platform#152 development target checkpoint
- Actor: OpenAI Codex /root
- Human authority: @adrian
- Agent / capacity provider: OpenAI Codex local workspace
- Exact base ref: staging 97bc058ecf637bb77e6a3cb472e03f65d0a29c5f
- Exact head ref: codex/dev-release-completion dd922d66d448caa259e7541a722e903a5d289d35

Contributor mode (select one):

- [ ] Human-authored
- [ ] Agent-assisted under human authority
- [x] Agent-authored under human authority

## Plan

Declare cloned provider state; withdraw availability before drain; block active or recovery claims; scope cleanup to the session root; verify contracts and tests. Complete.

## Changes and commits

- dd922d66d448caa259e7541a722e903a5d289d35 adds the runtime, drain verifier, manifest contract, and tests.

## Verification

- SDK development runtime schema validation: passed
- bash -n scripts/development/runtime.sh: passed
- npm run build:dist: passed
- npm test: 27 passed

## Risk and rollback

The runtime refuses cleanup with active/unsettled claims and validates the exact session path before removal. Roll back by reverting dd922d66d448caa259e7541a722e903a5d289d35; released provider state and images are untouched.

## Completion summary

Portable Agent rebuild/restart and zero-residue cleanup gates are implemented. Release/promotion follows after SDK custody publication.

## Submission checklist

- [x] The change is bounded to the stated work item and target repository.
- [x] Exact base and head refs are recorded and the branch is ready for review.
- [x] Verification and compatibility evidence are recorded above.
- [x] No plaintext secrets, credentials, machine state, or unrelated residue are included.
- [x] Plan, status, commits, and completion summary form a complete durable record.
- [x] Rollback or recovery steps are documented and executable.