### PR TITLE
ci: prefer normalized Docker credentials

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -36,7 +36,7 @@ jobs:
       - run: npm ci --ignore-scripts && npm run capacity-provider:build -- --prepare-only
       - uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f
       - uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9
-        with: { username: "${{ vars.DOCKERHUB_USERNAME }}", password: "${{ secrets.DOCKERHUB_TOKEN }}" }
+        with: { username: "${{ vars.DOCKERHUB_USERNAME || vars.TREESEED_DOCKERHUB_USERNAME }}", password: "${{ secrets.DOCKERHUB_TOKEN || secrets.TREESEED_DOCKERHUB_TOKEN }}" }
       - uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8
         with: { context: ., target: "${{ matrix.target }}", platforms: "${{ matrix.platform }}", push: true, tags: "${{ matrix.image }}:candidate-${{ github.sha }}-${{ matrix.arch }}", sbom: true, provenance: mode=max }
       - name: Verify candidate runner contains Codex
@@ -54,7 +54,7 @@ jobs:
       - run: npm ci --ignore-scripts --no-audit --no-fund
       - uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f
       - uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9
-        with: { username: "${{ vars.DOCKERHUB_USERNAME }}", password: "${{ secrets.DOCKERHUB_TOKEN }}" }
+        with: { username: "${{ vars.DOCKERHUB_USERNAME || vars.TREESEED_DOCKERHUB_USERNAME }}", password: "${{ secrets.DOCKERHUB_TOKEN || secrets.TREESEED_DOCKERHUB_TOKEN }}" }
       - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093
         with: { name: "agent-source-${{ github.sha }}", path: release-assets }
       - name: Seal manifests and component assets
@@ -83,7 +83,7 @@ jobs:
       - run: npm ci --ignore-scripts --no-audit --no-fund
       - uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f
       - uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9
-        with: { username: "${{ vars.DOCKERHUB_USERNAME }}", password: "${{ secrets.DOCKERHUB_TOKEN }}" }
+        with: { username: "${{ vars.DOCKERHUB_USERNAME || vars.TREESEED_DOCKERHUB_USERNAME }}", password: "${{ secrets.DOCKERHUB_TOKEN || secrets.TREESEED_DOCKERHUB_TOKEN }}" }
       - name: Download exact accepted candidate
         env: { GH_TOKEN: "${{ secrets.GITHUB_TOKEN }}" }
         run: |


### PR DESCRIPTION
## Outcome
Agent candidate publication prefers normalized Docker credential names and remains compatible with the repository's existing legacy names.
## Work authority
- Work item / Issue: treeseed-ai/platform#152
- Proposal / decision: User-approved Docker credential normalization
- Assignment / checkpoint: Agent candidate login recovery
- Actor: OpenAI Codex `/root`
- Human authority: @adriangbrandon
- Agent / capacity provider: OpenAI Codex
- Exact base ref: `staging` at 0b0d237d86b9a70fa65e19d38d34384a16230f03
- Exact head ref: `codex/dockerhub-credential-fallback` at 9dc49aa0e54e7970c3d78fa6039512608d871e01

Contributor mode (select one):
- [ ] Human-authored
- [ ] Agent-assisted under human authority
- [x] Agent-authored under human authority
## Plan
Prefer `DOCKERHUB_*`; fall back to the existing Agent `TREESEED_DOCKERHUB_*` repository values without exposing either.
## Changes and commits
- `9dc49aa0e54e7970c3d78fa6039512608d871e01` updates three protected login steps.
## Verification
- [x] I ran the narrowest relevant package verification and documented any checks that could not be run.
- Release publication suite: 4 passed.
- GitHub inventory confirms only the legacy Agent names currently exist.
## Risk and rollback
Revert one commit. No credentials are printed or copied.
## Completion summary
Agent supports normalized names without blocking its existing protected publisher.
## AGPL committer authorization
Base workflow validates the author.
## Submission checklist
- [x] The change is bounded to the stated work item and target repository.
- [x] Exact base and head refs are recorded and the branch is ready for review.
- [x] Verification and compatibility evidence are recorded above.
- [x] No plaintext secrets, credentials, machine state, or unrelated residue are included.
- [x] Plan, status, commits, and completion summary form a complete durable record.
- [x] Rollback or recovery steps are documented and executable.
