### PR TITLE
Bind provider registration replay to enrollment generation

### DIFF
--- a/src/provider/coordination/coordinator.ts
+++ b/src/provider/coordination/coordinator.ts
@@ -1,4 +1,4 @@
-import { randomUUID } from 'node:crypto';
+import { createHash, randomUUID } from 'node:crypto';
 import type {
 	CapacityProviderManifestV3,
 	CapacityProviderJoinInput,
@@ -74,6 +74,11 @@ function nextState(connectionId: string, controlPlaneUrl: string, prior: Provide
 	const next = { schemaVersion: 1 as const, connectionId, controlPlaneUrl, ...(prior ?? {}), ...patch, updatedAt: new Date().toISOString() };
 	if (!next.offer) throw new Error(`Provider connection ${connectionId} is missing its durable supply offer.`);
 	return next as ProviderConnectionState;
+}
+
+export function providerRegistrationIdempotencyKey(connectionId: string, registrationKey: string) {
+	const enrollmentGeneration = createHash('sha256').update(registrationKey).digest('hex').slice(0, 16);
+	return `register:${connectionId}:${enrollmentGeneration}`;
 }
 
 export class CapacityProviderCoordinator {
@@ -173,7 +178,7 @@ export class CapacityProviderCoordinator {
 		const proof = await this.proof({ audience: controlPlaneAudience, method: 'POST', path: providerOperationPath(CONTROL_PLANE_OPERATIONS.providers.register), body: unsigned, identity });
 		const submission: ProviderRegistrationSubmission = { ...unsigned, proof };
 		const registrationKey = oneTimeRegistrationKey ?? await resolveProviderSecret(join.registrationKeyRef, { env: this.options.env, baseDirectory: this.loaded.directory, dataDirectory: this.dataDir, resolver: this.options.secretResolver });
-		const request = await client.register(registrationKey, submission, `register:${join.id}`);
+		const request = await client.register(registrationKey, submission, providerRegistrationIdempotencyKey(join.id, registrationKey));
 		const state = nextState(join.id, controlPlaneUrl, null, { serverProfile: join.serverProfile ?? null, controlPlaneAudience, offer: join.offer, teamId: request.teamId, providerId: request.providerId, registrationRequestId: request.id, registrationStatus: request.status });
 		await writeProviderConnectionState(this.dataDir, state);
 		return { connectionId: join.id, status: 'pending-approval', teamId: request.teamId, providerId: request.providerId, requestId: request.id };

--- a/tests/modern/provider-boundary.test.ts
+++ b/tests/modern/provider-boundary.test.ts
@@ -4,6 +4,7 @@ import { resolve } from 'node:path';
 import { describe, expect, it } from 'vitest';
 import { CONTROL_PLANE_OPERATIONS } from '@treeseed/sdk/operator-contracts';
 import { providerOperationPath } from '../../src/provider/coordination/client.ts';
+import { providerRegistrationIdempotencyKey } from '../../src/provider/coordination/coordinator.ts';
 import { executorModuleSpecifier, resolveAgentExecutor } from '../../src/provider/execution/executor-loader.ts';
 import { resolveProviderConfig } from '../../src/provider/configuration/config.ts';
 import { ensureCapacityProviderIdentity } from '../../src/provider/accounts/identity.ts';
@@ -52,6 +53,13 @@ describe('Agent package ownership boundary', () => {
 		} finally {
 			rmSync(dataDirectory, { recursive: true, force: true });
 		}
+	});
+
+	it('binds registration idempotency to the enrollment generation', () => {
+		expect(providerRegistrationIdempotencyKey('primary', 'token-one'))
+			.toBe(providerRegistrationIdempotencyKey('primary', 'token-one'));
+		expect(providerRegistrationIdempotencyKey('primary', 'token-one'))
+			.not.toBe(providerRegistrationIdempotencyKey('primary', 'token-two'));
 	});
 
 	it('stores mutable connections in local custody without rewriting the canonical manifest', async () => {


### PR DESCRIPTION
## Outcome

A replacement provider enrollment token receives a distinct sealed registration identity while retries with the same token remain idempotent.

## Work authority

- Work item / Issue: TreeSeed bundled-platform final readiness check; related treeseed-ai/platform#161
- Proposal / decision: docs/dev-release.md local provider recovery and zero-residue acceptance
- Assignment / checkpoint: provider re-enrollment b4952ec3-0453-4941-882c-09c1f4f42ffe
- Actor: Codex primary integration agent
- Human authority: @adrianwebb
- Agent / capacity provider: provider_NUETJ-QBsASqmjYO1ohjHeVbCdLVrH_s / codex-local
- Exact base ref: staging baca4880b52b5104bc712636f4192f8abeacf291
- Exact head ref: codex/fix-provider-reenrollment-idempotency d167e9dda3f2dede29f53d1d05f26c8661ce4833

Contributor mode (select one):

- [ ] Human-authored
- [x] Agent-assisted under human authority
- [ ] Agent-authored under human authority

## Plan

Reproduce the sealed registration collision, bind replay identity to a non-secret digest of the enrollment generation, add boundary coverage, and prove replacement enrollment plus execution. Complete.

## Changes and commits

- d167e9dce93b0e5413c6782a8a89c07bc0064423 adds providerRegistrationIdempotencyKey and regression coverage for stable retry and distinct re-enrollment generations.

## Verification

- npm run test:modern -- tests/modern/provider-boundary.test.ts: 9 passed.
- npm run build:dist: passed.
- Replacement provider enrolled, was owner-approved, renewed availability, leased a communication assignment, produced a TreeDX response, and settled usage.

## Risk and rollback

The one-time key is never stored or emitted; only a 16-hex SHA-256 prefix joins the non-secret connection identity. Revert d167e9d to restore the previous key. Existing approved connections are unaffected.

## Completion summary

Provider recovery is replay-safe across enrollment generations and the recovered local Codex provider has completed a real control-plane assignment.

## Submission checklist

- [x] The change is bounded to the stated work item and target repository.
- [x] Exact base and head refs are recorded and the branch is ready for review.
- [x] Verification and compatibility evidence are recorded above.
- [x] No plaintext secrets, credentials, machine state, or unrelated residue are included.
- [x] Plan, status, commits, and completion summary form a complete durable record.
- [x] Rollback or recovery steps are documented and executable.