### PR TITLE
feat(security): run assignments in Kata sandboxes

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -29,6 +29,7 @@ jobs:
           - { image: treeseed/agent-manager, target: agent-manager, arch: arm64, platform: linux/arm64, runner: ubuntu-24.04-arm }
           - { image: treeseed/agent-runner, target: agent-runner, arch: amd64, platform: linux/amd64, runner: ubuntu-24.04 }
           - { image: treeseed/agent-runner, target: agent-runner, arch: arm64, platform: linux/arm64, runner: ubuntu-24.04-arm }
+          - { image: treeseed/agent-sandbox-guest, target: sandbox-guest, arch: amd64, platform: linux/amd64, runner: ubuntu-24.04 }
     steps:
       - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262
         with: { submodules: recursive }
@@ -41,7 +42,7 @@ jobs:
       - uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8
         with: { context: ., target: "${{ matrix.target }}", platforms: "${{ matrix.platform }}", push: true, tags: "${{ matrix.image }}:candidate-${{ github.sha }}-${{ matrix.arch }}", sbom: true, provenance: mode=max }
       - name: Verify candidate runner contains Codex
-        if: matrix.target == 'agent-runner'
+        if: matrix.target == 'agent-runner' || matrix.target == 'sandbox-guest'
         run: docker run --rm --entrypoint /usr/local/bin/codex "${{ matrix.image }}:candidate-${{ github.sha }}-${{ matrix.arch }}" --version | grep -Fx 'codex-cli 0.149.0'
   candidate-seal:
     if: github.ref == 'refs/heads/staging'
@@ -66,7 +67,9 @@ jobs:
             docker buildx imagetools create -t "${image}:${candidate}" "${image}:${candidate}-amd64" "${image}:${candidate}-arm64"
             digest="$(docker buildx imagetools inspect "${image}:${candidate}" --format '{{json .Manifest}}' | jq -r '.digest')"; [[ "$digest" =~ ^sha256:[a-f0-9]{64}$ ]]; export "TREESEED_${key}_DIGEST=$digest"
           done
-          export TREESEED_RELEASE="$(node -p "require('./package.json').version")" TREESEED_SOURCE_COMMIT="$GITHUB_SHA" TREESEED_MANAGER_DIGEST TREESEED_RUNNER_DIGEST
+          docker buildx imagetools create -t "treeseed/agent-sandbox-guest:candidate-${GITHUB_SHA}" "treeseed/agent-sandbox-guest:candidate-${GITHUB_SHA}-amd64"
+          TREESEED_GUEST_DIGEST="$(docker buildx imagetools inspect "treeseed/agent-sandbox-guest:candidate-${GITHUB_SHA}" --format '{{json .Manifest}}' | jq -r '.digest')"; [[ "$TREESEED_GUEST_DIGEST" =~ ^sha256:[a-f0-9]{64}$ ]]; export TREESEED_GUEST_DIGEST
+          export TREESEED_RELEASE="$(node -p "require('./package.json').version")" TREESEED_SOURCE_COMMIT="$GITHUB_SHA" TREESEED_MANAGER_DIGEST TREESEED_RUNNER_DIGEST TREESEED_GUEST_DIGEST
           node --import tsx scripts/release/create-component-release.ts
           npm run release:custody -- seal release-assets/release-evidence-v1.json release-assets
           npm run release:custody -- verify release-assets/release-evidence-v1.json

--- a/Dockerfile
+++ b/Dockerfile
@@ -22,12 +22,43 @@ COPY --chown=65532:65532 .treeseed/docker/runtime/shared/package.json .treeseed/
 COPY --chown=65532:65532 .treeseed/docker/runtime/shared/node_modules ./node_modules
 
 RUN test -x /app/node_modules/@openai/codex/bin/codex.js \
-	&& ln -s /app/node_modules/@openai/codex/bin/codex.js /usr/local/bin/codex
+	&& ln -s /app/node_modules/@openai/codex/bin/codex.js /usr/local/bin/codex \
+	&& CODE_MODE_HOST="$(find /app/node_modules/@openai -type f -path '*/bin/codex-code-mode-host' -print -quit)" \
+	&& test -n "$CODE_MODE_HOST" \
+	&& test -x "$CODE_MODE_HOST" \
+	&& ln -s "$CODE_MODE_HOST" /usr/local/bin/codex-code-mode-host
 
-FROM agent-runtime AS agent-manager
+FROM agent-provider-base AS agent-manager
 ENV TREESEED_PROVIDER_ROLE=manager
+USER 65532:65532
 CMD ["manager"]
 
-FROM agent-runtime AS agent-runner
+FROM agent-provider-base AS agent-runner
 ENV TREESEED_PROVIDER_ROLE=runner
+USER 65532:65532
 CMD ["runner"]
+
+FROM node:24-bookworm-slim AS sandbox-guest
+WORKDIR /app
+ENV HOME=/workspace/.treeseed/codex \
+	CODEX_HOME=/workspace/.treeseed/codex \
+	XDG_RUNTIME_DIR=/run/user/65532
+RUN apt-get update \
+	&& apt-get install -y --no-install-recommends bash build-essential ca-certificates fuse-overlayfs git openssh-client podman python3 slirp4netns tini uidmap \
+	&& rm -rf /var/lib/apt/lists/* \
+	&& useradd --uid 65532 --user-group --create-home --home-dir /workspace/.treeseed/codex treeseed \
+	&& printf 'treeseed:100000:65536\n' >> /etc/subuid \
+	&& printf 'treeseed:100000:65536\n' >> /etc/subgid \
+	&& mkdir -p /workspace /run/treeseed-output /run/user/65532 \
+	&& chown -R 65532:65532 /workspace /run/treeseed-output /run/user/65532
+COPY --chown=65532:65532 dist ./dist
+COPY --chown=65532:65532 .treeseed/docker/runtime/shared/package.json .treeseed/docker/runtime/shared/package-lock.json ./
+COPY --chown=65532:65532 .treeseed/docker/runtime/shared/node_modules ./node_modules
+RUN test -x /app/node_modules/@openai/codex/bin/codex.js \
+	&& ln -s /app/node_modules/@openai/codex/bin/codex.js /usr/local/bin/codex \
+	&& CODE_MODE_HOST="$(find /app/node_modules/@openai -type f -path '*/bin/codex-code-mode-host' -print -quit)" \
+	&& test -n "$CODE_MODE_HOST" \
+	&& test -x "$CODE_MODE_HOST" \
+	&& ln -s "$CODE_MODE_HOST" /usr/local/bin/codex-code-mode-host
+USER treeseed
+ENTRYPOINT ["/bin/bash", "-lc", "ulimit -u \"${TREESEED_SANDBOX_PROCESS_LIMIT:?}\"; ulimit -f \"$((TREESEED_SANDBOX_DISK_LIMIT / 512))\"; exec node /app/dist/sandbox/guest.js"]

--- a/compose.capacity-provider.yml
+++ b/compose.capacity-provider.yml
@@ -9,17 +9,14 @@ services:
     restart: unless-stopped
     extra_hosts: ["host.docker.internal:host-gateway"]
     environment: &provider-environment
-      TREESEED_CAPACITY_PROVIDER_SOURCE: /config/treeseed.capacity-provider.yaml
-      TREESEED_CAPACITY_PROVIDER_MANIFEST: /data/config/treeseed.capacity-provider.yaml
+      TREESEED_CAPACITY_PROVIDER_MANIFEST: /config/treeseed.capacity-provider.yaml
       TREESEED_PROVIDER_DATA_DIR: /data
       TREESEED_PROVIDER_ENVIRONMENT: ${TREESEED_PROVIDER_ENVIRONMENT:-local}
+      TREESEED_REQUIRE_MICROVM: "true"
+      TREESEED_PROVIDER_CREDENTIAL_KEK_FILE: /run/credentials/credentials
       TREESEED_PROVIDER_SOURCE_CLOSURE_DIGEST: ${TREESEED_PROVIDER_SOURCE_CLOSURE_DIGEST:-}
       TREESEED_SERVER_PROFILE_LOCAL_URL: ${TREESEED_SERVER_PROFILE_LOCAL_URL:-http://host.docker.internal:3002}
       TREESEED_SERVER_PROFILE_LOCAL_AUDIENCE: ${TREESEED_SERVER_PROFILE_LOCAL_AUDIENCE:-http://127.0.0.1:3002}
-      TREESEED_AGENT_EXECUTOR_MODULE: ${TREESEED_AGENT_EXECUTOR_MODULE:-module:codex-chat}
-      TREESEED_CODEX_EXECUTABLE: /usr/local/bin/codex
-      TREESEED_CODEX_AUTH_SOURCE: /run/treeseed-secrets/codex-auth.json
-      TREESEED_CODEX_AUTH_FILE: /data/credentials/codex-auth.json
       TREESEED_PROVIDER_MAX_CONCURRENT_WORKDAYS: ${TREESEED_PROVIDER_MAX_CONCURRENT_WORKDAYS:-1}
       TREESEED_PROVIDER_MAX_CONCURRENT_RUNNERS: ${TREESEED_PROVIDER_MAX_CONCURRENT_RUNNERS:-1}
       TREESEED_PROVIDER_DAILY_AGENT_SECONDS_LIMIT: ${TREESEED_PROVIDER_DAILY_AGENT_SECONDS_LIMIT:-}
@@ -28,7 +25,11 @@ services:
     volumes: &provider-volumes
       - "${TREESEED_PROVIDER_HOST_DATA_DIR:-.treeseed/local-capacity-providers/agent-standalone}:/data"
       - "${TREESEED_CAPACITY_PROVIDER_MANIFEST:-./treeseed.capacity-provider.yaml}:/config/treeseed.capacity-provider.yaml:ro"
-      - "${TREESEED_CODEX_AUTH_HOST_FILE:-${HOME}/.codex/auth.json}:/run/treeseed-secrets/codex-auth.json:ro"
+      - "/run/treeseed/sandbox/broker.sock:/run/treeseed/sandbox/broker.sock"
+      - "/etc/treeseed/sandbox/relay-ca.crt:/etc/treeseed/sandbox/relay-ca.crt:ro"
+      - "/run/treeseed/component-credentials/agent:/run/credentials:ro"
+    group_add: &broker-groups
+      - "${TREESEED_SANDBOX_BROKER_GID:-65532}"
   runner:
     image: ${TREESEED_AGENT_RUNNER_IMAGE:-treeseed/agent-runner:${TREESEED_AGENT_IMAGE_TAG:-local}}
     build:
@@ -41,3 +42,4 @@ services:
     environment:
       <<: *provider-environment
     volumes: *provider-volumes
+    group_add: *broker-groups

--- a/deploy/compose.template.yml
+++ b/deploy/compose.template.yml
@@ -5,16 +5,13 @@ services:
     command: ["manager"]
     restart: unless-stopped
     environment: &provider-environment
-      TREESEED_CAPACITY_PROVIDER_SOURCE: /config/treeseed.capacity-provider.yaml
-      TREESEED_CAPACITY_PROVIDER_MANIFEST: /data/config/treeseed.capacity-provider.yaml
+      TREESEED_CAPACITY_PROVIDER_MANIFEST: /config/treeseed.capacity-provider.yaml
       TREESEED_PROVIDER_DATA_DIR: /data
       TREESEED_PROVIDER_ENVIRONMENT: ${TREESEED_PROVIDER_ENVIRONMENT:-managed}
+      TREESEED_REQUIRE_MICROVM: "true"
+      TREESEED_PROVIDER_CREDENTIAL_KEK_FILE: /run/credentials/credentials
       TREESEED_SERVER_PROFILE_LOCAL_URL: ${TREESEED_CONTROL_PLANE_URL:?TREESEED_CONTROL_PLANE_URL is required}
       TREESEED_SERVER_PROFILE_LOCAL_AUDIENCE: ${TREESEED_CONTROL_PLANE_AUDIENCE:?TREESEED_CONTROL_PLANE_AUDIENCE is required}
-      TREESEED_AGENT_EXECUTOR_MODULE: ${TREESEED_AGENT_EXECUTOR_MODULE:-module:codex-chat}
-      TREESEED_CODEX_EXECUTABLE: /usr/local/bin/codex
-      TREESEED_CODEX_AUTH_SOURCE: /run/treeseed-secrets/codex-auth.json
-      TREESEED_CODEX_AUTH_FILE: /data/credentials/codex-auth.json
       TREESEED_PROVIDER_MAX_CONCURRENT_WORKDAYS: ${TREESEED_PROVIDER_MAX_CONCURRENT_WORKDAYS:-1}
       TREESEED_PROVIDER_MAX_CONCURRENT_RUNNERS: ${TREESEED_PROVIDER_MAX_CONCURRENT_RUNNERS:-1}
     volumes: &provider-volumes
@@ -26,9 +23,18 @@ services:
         target: /config/treeseed.capacity-provider.yaml
         read_only: true
       - type: bind
-        source: /etc/treeseed/credentials/agent-codex-auth
-        target: /run/treeseed-secrets/codex-auth.json
+        source: /run/treeseed/sandbox/broker.sock
+        target: /run/treeseed/sandbox/broker.sock
+      - type: bind
+        source: /etc/treeseed/sandbox/relay-ca.crt
+        target: /etc/treeseed/sandbox/relay-ca.crt
         read_only: true
+      - type: bind
+        source: /run/treeseed/component-credentials/agent
+        target: /run/credentials
+        read_only: true
+    group_add: &broker-groups
+      - "${TREESEED_SANDBOX_BROKER_GID:?TREESEED_SANDBOX_BROKER_GID is required}"
     networks: [private, platform]
     healthcheck:
       test: ["CMD", "/app/docker-entrypoint.sh", "healthcheck", "--json"]
@@ -43,6 +49,7 @@ services:
     restart: unless-stopped
     environment: *provider-environment
     volumes: *provider-volumes
+    group_add: *broker-groups
     networks: [private, platform]
     healthcheck:
       test: ["CMD", "/app/docker-entrypoint.sh", "healthcheck", "--json"]

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,55 +1,14 @@
 #!/usr/bin/env sh
 set -eu
 
-DATA_DIR="${TREESEED_PROVIDER_DATA_DIR:-/data}"
-APP_UID="${TREESEED_PROVIDER_UID:-65532}"
-APP_GID="${TREESEED_PROVIDER_GID:-65532}"
-CHOWN_DATA="${TREESEED_PROVIDER_CHOWN_DATA:-1}"
-CODEX_AUTH_SOURCE="${TREESEED_CODEX_AUTH_SOURCE:-}"
-CODEX_AUTH_FILE="${TREESEED_CODEX_AUTH_FILE:-$DATA_DIR/credentials/codex-auth.json}"
-MANIFEST_SOURCE="${TREESEED_CAPACITY_PROVIDER_SOURCE:-}"
-MANIFEST_FILE="${TREESEED_CAPACITY_PROVIDER_MANIFEST:-$DATA_DIR/config/treeseed.capacity-provider.yaml}"
-
-if [ "$(id -u)" = "0" ] && [ "${1:-}" = "healthcheck" ]; then
-	exec setpriv --reuid "$APP_UID" --regid "$APP_GID" --clear-groups node ./dist/provider/lifecycle/entrypoint.js "$@"
+if [ "$(id -u)" = "0" ]; then
+	echo "TreeSeed provider manager and runner containers must run unprivileged." >&2
+	exit 78
 fi
 
-mkdir -p "$DATA_DIR"
-
-if [ "$(id -u)" = "0" ]; then
-	if [ "$CHOWN_DATA" != "0" ]; then
-		chown -R "$APP_UID:$APP_GID" "$DATA_DIR"
-	fi
-	if [ -n "$MANIFEST_SOURCE" ]; then
-		if [ ! -f "$MANIFEST_SOURCE" ] || [ -L "$MANIFEST_SOURCE" ]; then
-			echo "Capacity-provider manifest source must be a regular, non-symlink file." >&2
-			exit 78
-		fi
-		case "$MANIFEST_FILE" in
-			"$DATA_DIR"/config/*) ;;
-			*) echo "Capacity-provider manifest target must remain in the provider configuration directory." >&2; exit 78 ;;
-		esac
-		mkdir -p "$(dirname "$MANIFEST_FILE")"
-		cp "$MANIFEST_SOURCE" "$MANIFEST_FILE"
-		chmod 0600 "$MANIFEST_FILE"
-		chown "$APP_UID:$APP_GID" "$MANIFEST_FILE"
-		export TREESEED_CAPACITY_PROVIDER_MANIFEST="$MANIFEST_FILE"
-	fi
-	if [ -n "$CODEX_AUTH_SOURCE" ]; then
-		if [ ! -f "$CODEX_AUTH_SOURCE" ] || [ -L "$CODEX_AUTH_SOURCE" ]; then
-			echo "Codex authentication source must be a regular, non-symlink file." >&2
-			exit 78
-		fi
-		case "$CODEX_AUTH_FILE" in
-			"$DATA_DIR"/credentials/*) ;;
-			*) echo "Codex authentication target must remain in the provider credential directory." >&2; exit 78 ;;
-		esac
-		mkdir -p "$(dirname "$CODEX_AUTH_FILE")"
-		cp "$CODEX_AUTH_SOURCE" "$CODEX_AUTH_FILE"
-		chmod 0600 "$CODEX_AUTH_FILE"
-		chown "$APP_UID:$APP_GID" "$CODEX_AUTH_FILE"
-	fi
-	exec setpriv --reuid "$APP_UID" --regid "$APP_GID" --clear-groups node ./dist/provider/lifecycle/entrypoint.js "$@"
+DATA_DIR="${TREESEED_PROVIDER_DATA_DIR:-/data}"
+if [ -n "${TREESEED_PROVIDER_CREDENTIAL_HISTORICAL_KEY_FILES:-}" ]; then
+	node ./dist/provider/security/rewrap-vault.js "$DATA_DIR"
 fi
 
 exec node ./dist/provider/lifecycle/entrypoint.js "$@"

--- a/docs/capacity-provider-runtime.md
+++ b/docs/capacity-provider-runtime.md
@@ -11,11 +11,13 @@ The package does not host an API, persist control-plane records, synthesize work
 
 ## Trusted executor boundary
 
-Model/runtime implementation is injected through `TREESEED_AGENT_EXECUTOR_MODULE`. The module must export `createAgentExecutor()` and implement the package's `AgentExecutor` contract. Without a configured and healthy executor, the manager advertises no executable capacity and the runner does not request work.
+Production manifests use schema v4 and `microvm` adapters. Manager and runner images are unprivileged and contain neither Codex nor its authentication. They receive only `/data`, component configuration, a runtime application-key file, and the root broker's Unix socket. Without a healthy KVM/Kata broker and an authorized immutable guest image, the manager advertises the adapter as unavailable and a runner returns any raced lease immediately.
 
-The published manager and runner images include the exact Codex CLI version declared by the package lock. The managed production bundle defaults to the built-in `module:codex-chat` executor and accepts the Codex login cache only from the root-owned `/etc/treeseed/credentials/agent-codex-auth` host file. The root entrypoint validates that mount, copies it with mode `0600` into manager-owned provider state, and drops privileges before starting Node. Each assignment then uses an isolated temporary `CODEX_HOME` and deletes it after execution. Credentials must never be baked into an image, supplied through an environment variable, or committed to a repository.
+For every attempt the executor materializes exact Git and TreeDX snapshots, verifies identity/profile/objective/template sources, signs their digests and limits, and uploads them to the broker. The broker launches a unique Kata QEMU/KVM guest. Read assignments receive immutable inputs; acting assignments receive a private copy-on-write workspace and can return only declared, digest-verified artifacts. Lease renewal is separately provider-signed, and lease loss, cancellation, timeout, or settlement destroys the VM.
 
-The executor receives only an API-issued assignment, lease identity, runner identity, and cancellation signal. Repository, TreeDX, model, and provider credentials must arrive through trusted provider receipts or host custody; they do not belong in agent definitions or source worktrees.
+Codex exists only in the pinned guest image. It calls a loopback relay with a one-use assignment token; the host model gateway injects the real service credential after enforcing the signed provider, model, capability, output-token, cost, and expiry policy. Real Codex/provider authentication is never mounted in the guest or provider containers. Long-lived credentials must never be baked into an image, supplied through a manifest/environment variable, or committed to a repository.
+
+Conversation executors participate in team-wide discussion topics. Responses use `@project/agent` for an exact handoff and `@agent` to address every matching chat-enabled agent across the team. The API routes each handoff into the target project's isolated TreeDX discussion stream; the provider never broadens project authority itself.
 
 ## Local profile
 
@@ -31,7 +33,7 @@ Secrets are referenced from the manifest and resolved only on the trusted provid
 
 ## Recovery and completion
 
-Provider-local state exists only to prevent double-spending and recover leases across process restarts. On restart the runtime re-reads authoritative assignment state. A leased or running assignment is returned before local state is released. Successful execution follows:
+Provider-local state exists only to prevent double-spending and recover leases across process restarts. It resides on the LUKS2 provider volume, and reversible `data://` credentials are application-encrypted envelopes. On restart the runtime re-reads authoritative assignment state; the host broker destroys untrusted residual containerd sandboxes rather than reattaching them. A leased or running assignment is returned before local state is released. Successful execution follows:
 
 1. start execution;
 2. execute through the trusted executor;
@@ -41,3 +43,6 @@ Provider-local state exists only to prevent double-spending and recover leases a
 6. submit the terminal completion receipt.
 
 Errors produce typed failure or return receipts. Local cleanup never substitutes for an authoritative API terminal response.
+# Governance inbox artifacts
+
+Conversation and planning assignments may create TreeDX-backed questions and proposals when their scoped activity profile permits it. Questions must identify an owning project, requested audience, related objectives, and answer policy. Proposals must include their governed proposal type, evidence, objective links, and complete plan. The provider must return exact content paths and immutable commit evidence; it must never report a proposal as approved without a correlated exact-version governance decision.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,16 +1,16 @@
 {
   "name": "@treeseed/agent",
-  "version": "0.13.0-rc.25",
+  "version": "0.13.0-rc.26",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@treeseed/agent",
-      "version": "0.13.0-rc.25",
+      "version": "0.13.0-rc.26",
       "license": "Apache-2.0",
       "dependencies": {
         "@openai/codex": "0.149.0",
-        "@treeseed/sdk": "0.13.0-rc.47",
+        "@treeseed/sdk": "0.13.0-rc.55",
         "esbuild": "0.28.2",
         "typescript": "^5.9.3",
         "yaml": "^2.8.1"
@@ -850,9 +850,9 @@
       "license": "MIT"
     },
     "node_modules/@treeseed/sdk": {
-      "version": "0.13.0-rc.47",
-      "resolved": "https://registry.npmjs.org/@treeseed/sdk/-/sdk-0.13.0-rc.47.tgz",
-      "integrity": "sha512-Z5biEwnNJ2+kOFOxiUyeDIE/zTpCGe7zSyqkQOwO/K/HAfCtAT7kH1KRQ9DEzyHNdonhqsMViHQoxXY0TsATiA==",
+      "version": "0.13.0-rc.55",
+      "resolved": "https://registry.npmjs.org/@treeseed/sdk/-/sdk-0.13.0-rc.55.tgz",
+      "integrity": "sha512-UG4LcWfu+gmhtSOd3T2NNc+LtDqTSVlSdLpfhT5R79ifRIO5I+zgonYgudZe9HJmcl6OJdjjpdHg0XS8hNDpdg==",
       "license": "Apache-2.0",
       "dependencies": {
         "@treeseed/treedx": "0.3.0-rc.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@treeseed/agent",
-  "version": "0.13.0-rc.25",
+  "version": "0.13.0-rc.26",
   "description": "Treeseed agent service runtime package.",
   "license": "Apache-2.0",
   "repository": {
@@ -68,7 +68,7 @@
   },
   "dependencies": {
     "@openai/codex": "0.149.0",
-    "@treeseed/sdk": "0.13.0-rc.47",
+    "@treeseed/sdk": "0.13.0-rc.55",
     "esbuild": "0.28.2",
     "typescript": "^5.9.3",
     "yaml": "^2.8.1"

--- a/scripts/capacity/providers/build-capacity-provider-container.ts
+++ b/scripts/capacity/providers/build-capacity-provider-container.ts
@@ -15,6 +15,7 @@ const dockerBuildAttempts = Number(process.env.TREESEED_AGENT_DOCKER_BUILD_ATTEM
 const roleImages = {
 	manager: process.env.TREESEED_AGENT_MANAGER_IMAGE || `treeseed/agent-manager:${imageTag}`,
 	runner: process.env.TREESEED_AGENT_RUNNER_IMAGE || `treeseed/agent-runner:${imageTag}`,
+	guest: process.env.TREESEED_AGENT_SANDBOX_GUEST_IMAGE || `treeseed/agent-sandbox-guest:${imageTag}`,
 } as const;
 type RoleName = keyof typeof roleImages;
 
@@ -25,11 +26,11 @@ function sharedRuntimeRoot() {
 function parseSelectedRoles(): Set<RoleName> {
 	const rolesFlagIndex = process.argv.indexOf('--roles');
 	const rawRoles = rolesFlagIndex >= 0 ? process.argv[rolesFlagIndex + 1] : process.env.TREESEED_AGENT_BUILD_ROLES;
-	const allRoles: RoleName[] = ['manager', 'runner'];
+	const allRoles: RoleName[] = ['manager', 'runner', 'guest'];
 	if (!rawRoles) return new Set(allRoles);
 	const selected = new Set<RoleName>();
 	for (const rawRole of rawRoles.split(',').map((role) => role.trim()).filter(Boolean)) {
-		if (rawRole !== 'manager' && rawRole !== 'runner') {
+		if (rawRole !== 'manager' && rawRole !== 'runner' && rawRole !== 'guest') {
 			throw new Error(`Unsupported capacity provider image role: ${rawRole}`);
 		}
 		selected.add(rawRole);
@@ -323,6 +324,9 @@ if (selectedRoles.has('manager')) {
 }
 if (selectedRoles.has('runner')) {
 	runDockerBuildWithRetry(['build', ...dockerBuildCacheArgs(), '--target', 'agent-runner', '-t', roleImages.runner, '.'], packageRoot);
+}
+if (selectedRoles.has('guest')) {
+	runDockerBuildWithRetry(['build', ...dockerBuildCacheArgs(), '--target', 'sandbox-guest', '-t', roleImages.guest, '.'], packageRoot);
 }
 console.log(`Built capacity provider image roles ${[...selectedRoles].join(', ')} from ${packageRoot}.`);
 

--- a/scripts/development/runtime.sh
+++ b/scripts/development/runtime.sh
@@ -3,10 +3,57 @@ set -euo pipefail
 
 session_id="${TREESEED_DEVELOPMENT_SESSION_ID:?TREESEED_DEVELOPMENT_SESSION_ID is required}"
 worktree="${TREESEED_DEVELOPMENT_WORKTREE:?TREESEED_DEVELOPMENT_WORKTREE is required}"
+: "${TREESEED_CAPACITY_PROVIDER_MANIFEST:=/etc/treeseed/components/agent/treeseed.capacity-provider.yaml}"
+: "${TREESEED_CODEX_AUTH_HOST_FILE:=/etc/treeseed/credentials/agent-codex-auth}"
+export TREESEED_CAPACITY_PROVIDER_MANIFEST TREESEED_CODEX_AUTH_HOST_FILE
 project="treeseed-agent-${session_id//[^a-zA-Z0-9_-]/-}"
 session_root="$worktree/.treeseed/cache/development-sessions/$session_id/provider"
 state_file="$session_root/runtime/capacity-state.json"
 export TREESEED_PROVIDER_HOST_DATA_DIR="$session_root"
+
+clone_released_connection_custody() {
+  local released_container="${TREESEED_RELEASED_PROVIDER_MANAGER_CONTAINER:-treeseed-agent-manager-1}"
+  docker inspect "$released_container" >/dev/null 2>&1 || {
+    printf 'Released provider connection custody is unavailable for the required development clone.\n' >&2
+    return 1
+  }
+  local released_image
+  released_image="$(docker inspect --format '{{.Config.Image}}' "$released_container")"
+  docker run --rm --user 0 --volumes-from "$released_container:ro" --volume "$session_root:/candidate" --entrypoint sh "$released_image" -c \
+    'cp -a /data/connections.yaml /data/identity-v3.json /data/connections /data/secrets /candidate/'
+  docker run --rm --user 0 --env TARGET_URL --volume "$session_root:/candidate" --entrypoint node "$released_image" -e \
+    'const fs=require("fs"),root="/candidate/connections"; for(const name of fs.readdirSync(root)){if(!name.endsWith(".json"))continue;const path=`${root}/${name}`,value=JSON.parse(fs.readFileSync(path,"utf8"));value.controlPlaneUrl=process.env.TARGET_URL;fs.writeFileSync(path,`${JSON.stringify(value,null,2)}\n`,{mode:0o600});} const custody="/candidate/connections.yaml";fs.writeFileSync(custody,fs.readFileSync(custody,"utf8").replace(/(^\s*controlPlaneUrl:\s*).+$/gmu,`$1${process.env.TARGET_URL}`),{mode:0o600});' \
+    --
+}
+
+connect_control_plane_network() {
+  local network="${TREESEED_CONTROL_PLANE_DOCKER_NETWORK:-treeseed-platform}"
+  local target_url="${TREESEED_DEVELOPMENT_CONTROL_PLANE_URL:-http://api-live:3000}"
+  export TARGET_URL="$target_url"
+  for service in manager runner; do
+    local container="${project}-${service}-1"
+    docker network connect "$network" "$container" >/dev/null 2>&1 || true
+  done
+}
+
+pause_released_provider() {
+  docker stop "${TREESEED_RELEASED_PROVIDER_MANAGER_CONTAINER:-treeseed-agent-manager-1}" \
+    "${TREESEED_RELEASED_PROVIDER_RUNNER_CONTAINER:-treeseed-agent-runner-1}" >/dev/null
+}
+
+restore_released_provider() {
+  docker start "${TREESEED_RELEASED_PROVIDER_RUNNER_CONTAINER:-treeseed-agent-runner-1}" \
+    "${TREESEED_RELEASED_PROVIDER_MANAGER_CONTAINER:-treeseed-agent-manager-1}" >/dev/null 2>&1 || true
+}
+
+remove_candidate_data() {
+  local released_container="${TREESEED_RELEASED_PROVIDER_MANAGER_CONTAINER:-treeseed-agent-manager-1}"
+  local released_image
+  released_image="$(docker inspect --format '{{.Config.Image}}' "$released_container")"
+  docker run --rm --user 0 --volume "$session_root:/candidate" --entrypoint sh "$released_image" -c \
+    'find /candidate -mindepth 1 -maxdepth 1 -exec rm -rf -- {} +'
+  rmdir "$session_root" 2>/dev/null || true
+}
 
 compose() {
   docker compose --file compose.capacity-provider.yml --project-name "$project" "$@"
@@ -19,11 +66,18 @@ drain() {
 
 case "${1:-}" in
   rebuild)
-    test -f "${TREESEED_CAPACITY_PROVIDER_MANIFEST:?TREESEED_CAPACITY_PROVIDER_MANIFEST is required}"
-    test -f "${TREESEED_CODEX_AUTH_HOST_FILE:?TREESEED_CODEX_AUTH_HOST_FILE is required}"
     mkdir -p "$session_root"
     drain
-    exec docker compose --file compose.capacity-provider.yml --project-name "$project" up --build --remove-orphans
+    export TARGET_URL="${TREESEED_DEVELOPMENT_CONTROL_PLANE_URL:-http://api-live:3000}"
+    clone_released_connection_custody
+    npm run capacity-provider:build
+    compose build
+    trap restore_released_provider ERR
+    pause_released_provider
+    compose up --remove-orphans --detach
+    connect_control_plane_network
+    trap - ERR
+    exec docker compose --file compose.capacity-provider.yml --project-name "$project" logs --follow
     ;;
   drain)
     drain
@@ -36,8 +90,9 @@ case "${1:-}" in
   cleanup)
     drain
     compose down --remove-orphans
+    restore_released_provider
     case "$session_root" in
-      "$worktree/.treeseed/cache/development-sessions/$session_id/provider") rm -rf -- "$session_root" ;;
+      "$worktree/.treeseed/cache/development-sessions/$session_id/provider") remove_candidate_data ;;
       *) printf 'Refusing unsafe provider cleanup path\n' >&2; exit 1 ;;
     esac
     ;;

--- a/scripts/release/create-component-release.ts
+++ b/scripts/release/create-component-release.ts
@@ -4,10 +4,10 @@ import { resolve } from 'node:path';
 import { componentReleaseSchema, deploymentDigest } from '@treeseed/sdk/deployment';
 
 const release = process.env.TREESEED_RELEASE, sourceCommit = process.env.TREESEED_SOURCE_COMMIT;
-const managerDigest = process.env.TREESEED_MANAGER_DIGEST, runnerDigest = process.env.TREESEED_RUNNER_DIGEST;
-if (!release || !sourceCommit || !managerDigest || !runnerDigest) throw new Error('Release, exact source commit, and both multi-architecture image digests are required.');
+const managerDigest = process.env.TREESEED_MANAGER_DIGEST, runnerDigest = process.env.TREESEED_RUNNER_DIGEST, guestDigest = process.env.TREESEED_GUEST_DIGEST;
+if (!release || !sourceCommit || !managerDigest || !runnerDigest || !guestDigest) throw new Error('Release, exact source commit, manager, runner, and sandbox guest image digests are required.');
 const digest = /^sha256:[a-f0-9]{64}$/u;
-if (!/^[a-f0-9]{40}$/u.test(sourceCommit) || !digest.test(managerDigest) || !digest.test(runnerDigest)) throw new Error('Source or image digest is malformed.');
+if (!/^[a-f0-9]{40}$/u.test(sourceCommit) || !digest.test(managerDigest) || !digest.test(runnerDigest) || !digest.test(guestDigest)) throw new Error('Source or image digest is malformed.');
 const track = release.includes('-rc.') ? 'development' : 'stable';
 const revision = Number(process.env.TREESEED_COMPONENT_REVISION ?? '1');
 if (!Number.isInteger(revision) || revision < 1) throw new Error('Component revision must be a positive integer.');
@@ -33,9 +33,10 @@ const bundle = componentReleaseSchema.parse({
 	images: [
 		{ role: 'agent-manager', repository: 'treeseed/agent-manager', digest: managerDigest, platforms: ['linux/amd64', 'linux/arm64'], consumers: ['agent'] },
 		{ role: 'agent-runner', repository: 'treeseed/agent-runner', digest: runnerDigest, platforms: ['linux/amd64', 'linux/arm64'], consumers: ['agent'] },
+		{ role: 'sandbox-guest', repository: 'treeseed/agent-sandbox-guest', digest: guestDigest, platforms: ['linux/amd64'], consumers: ['agent'] },
 	],
 	runtime, runtimeDigest: deploymentDigest(runtime), rollback: { compatible: true, requiresBackup: true },
-	evidence: { provenance: [tagUrl('treeseed/agent-manager'), tagUrl('treeseed/agent-runner')], sboms: [tagUrl('treeseed/agent-manager'), tagUrl('treeseed/agent-runner')], vulnerabilities: [] },
+	evidence: { provenance: [tagUrl('treeseed/agent-manager'), tagUrl('treeseed/agent-runner'), tagUrl('treeseed/agent-sandbox-guest')], sboms: [tagUrl('treeseed/agent-manager'), tagUrl('treeseed/agent-runner'), tagUrl('treeseed/agent-sandbox-guest')], vulnerabilities: [] },
 });
 const output = resolve('release-assets'); mkdirSync(output, { recursive: true });
 writeFileSync(resolve(output, 'compose.yml'), compose);

--- a/scripts/release/release-custody.ts
+++ b/scripts/release/release-custody.ts
@@ -11,8 +11,8 @@ if (process.argv[2] === 'seal') {
 	const output = resolve(root, process.argv[4] ?? 'release-assets');
 	const pkg = JSON.parse(readFileSync(resolve(root, 'package.json'), 'utf8')) as { name: string; version: string };
 	const sourceCommit = execFileSync('git', ['rev-parse', 'HEAD'], { cwd: root, encoding: 'utf8' }).trim();
-	const images = [['manager', 'treeseed/agent-manager', process.env.TREESEED_MANAGER_DIGEST], ['runner', 'treeseed/agent-runner', process.env.TREESEED_RUNNER_DIGEST]] as const;
-	if (images.some(([, , digest]) => !/^sha256:[a-f0-9]{64}$/u.test(digest ?? ''))) throw new Error('Both exact Agent OCI manifest digests are required.');
+	const images = [['manager', 'treeseed/agent-manager', process.env.TREESEED_MANAGER_DIGEST], ['runner', 'treeseed/agent-runner', process.env.TREESEED_RUNNER_DIGEST], ['guest', 'treeseed/agent-sandbox-guest', process.env.TREESEED_GUEST_DIGEST]] as const;
+	if (images.some(([, , digest]) => !/^sha256:[a-f0-9]{64}$/u.test(digest ?? ''))) throw new Error('Manager, runner, and sandbox guest exact OCI manifest digests are required.');
 	const artifacts: Array<{ id: string; kind: 'oci-image' | 'npm-package' | 'archive' | 'sbom' | 'component-manifest' | 'compose'; identity: string; digest: `sha256:${string}`; mediaType: string; size?: number }> = images.map(([id, image, digest]) => ({ id: `${id}-image`, kind: 'oci-image', identity: `${image}@${digest}`, digest: digest! as `sha256:${string}`, mediaType: 'application/vnd.oci.image.index.v1+json' }));
 	for (const name of readdirSync(output).filter((name) => name !== basename(evidencePath)).sort()) {
 		const path = resolve(output, name); if (!statSync(path).isFile()) continue;

--- a/src/provider/configuration/config.ts
+++ b/src/provider/configuration/config.ts
@@ -1,5 +1,5 @@
 import { existsSync, readFileSync } from 'node:fs';
-import type { CapacityProviderManifestV3 } from '@treeseed/sdk/capacity-provider';
+import type { CapacityProviderManifest } from '@treeseed/sdk/capacity-provider';
 
 export type ProviderRole = 'manager' | 'runner' | 'enroll' | 'doctor' | 'healthcheck' | 'plan' | 'version';
 
@@ -29,9 +29,9 @@ export interface ProviderConnectionRuntimeContext extends ProviderHostRuntimeCon
   membershipId: string;
   accessToken: string;
   accessTokenProvider?: (minimumValidityMs?: number) => Promise<string>;
-  adapters: CapacityProviderManifestV3['adapters'];
-  lanes: CapacityProviderManifestV3['lanes'];
-  providerCapacity: CapacityProviderManifestV3['capacity'];
+  adapters: CapacityProviderManifest['adapters'];
+  lanes: CapacityProviderManifest['lanes'];
+  providerCapacity: CapacityProviderManifest['capacity'];
 }
 
 function value(env: NodeJS.ProcessEnv, name: string) {

--- a/src/provider/configuration/manifest.ts
+++ b/src/provider/configuration/manifest.ts
@@ -3,10 +3,12 @@ import { dirname, isAbsolute, resolve } from 'node:path';
 import { parse as parseYaml, stringify as stringifyYaml } from 'yaml';
 import {
 	validateCapacityProviderManifestV3,
+	validateCapacityProviderManifestV4,
 	type CapacityProviderJoinInput,
-	type CapacityProviderManifestV3,
+	type CapacityProviderManifest,
 	type ProviderConnectionConfig,
 } from '@treeseed/sdk/capacity-provider';
+import { decryptProviderCredential, encryptProviderCredential, isProviderCredentialEnvelope } from '../security/credential-vault.ts';
 
 export const DEFAULT_PROVIDER_MANIFEST = 'treeseed.capacity-provider.yaml';
 
@@ -14,7 +16,7 @@ export interface LoadedProviderManifest {
 	path: string;
 	directory: string;
 	dataDirectory?: string;
-	manifest: CapacityProviderManifestV3;
+	manifest: CapacityProviderManifest;
 }
 
 export interface ProviderSecretResolver {
@@ -41,10 +43,11 @@ async function localConnections(dataDirectory: string | undefined) {
 
 export async function loadProviderManifest(path = process.env.TREESEED_CAPACITY_PROVIDER_MANIFEST || DEFAULT_PROVIDER_MANIFEST, dataDirectory?: string): Promise<LoadedProviderManifest> {
 	const absolute = resolve(path);
-	const parsed = parseYaml(await readFile(absolute, 'utf8')) as CapacityProviderManifestV3;
+	const parsed = parseYaml(await readFile(absolute, 'utf8')) as CapacityProviderManifest;
 	const overlay = await localConnections(dataDirectory);
 	const manifest = overlay ? { ...parsed, connections: overlay } : parsed;
-	const validation = validateCapacityProviderManifestV3(manifest);
+	if (process.env.TREESEED_REQUIRE_MICROVM === 'true' && manifest.schemaVersion !== 4) throw new Error('This provider requires a v4 microVM-only manifest; process-isolated migration manifests are rejected.');
+	const validation = manifest.schemaVersion === 4 ? validateCapacityProviderManifestV4(manifest) : validateCapacityProviderManifestV3(manifest);
 	if (!validation.ok) throw new Error(`Invalid capacity provider manifest: ${diagnosticMessage(validation.diagnostics)}`);
 	return { path: absolute, directory: dirname(absolute), ...(dataDirectory ? { dataDirectory } : {}), manifest };
 }
@@ -52,7 +55,7 @@ export async function loadProviderManifest(path = process.env.TREESEED_CAPACITY_
 export async function writeProviderConnections(loaded: LoadedProviderManifest, connections: ProviderConnectionConfig[]) {
 	if (!loaded.dataDirectory) throw new Error('Provider connection updates require a local data directory.');
 	const manifest = { ...loaded.manifest, connections };
-	const validation = validateCapacityProviderManifestV3(manifest);
+	const validation = manifest.schemaVersion === 4 ? validateCapacityProviderManifestV4(manifest) : validateCapacityProviderManifestV3(manifest);
 	if (!validation.ok) throw new Error(`Invalid capacity provider manifest: ${diagnosticMessage(validation.diagnostics)}`);
 	const path = connectionOverlayPath(loaded.dataDirectory);
 	await mkdir(dirname(path), { recursive: true, mode: 0o700 });
@@ -95,8 +98,15 @@ export async function resolveProviderSecret(ref: string, input: {
 	}
 	if (ref.startsWith('file://') || ref.startsWith('data://')) {
 		const path = secretReferencePath(ref, input.baseDirectory, input.dataDirectory);
-		const value = (await readFile(path, 'utf8')).trim();
+		const serialized = (await readFile(path, 'utf8')).trim();
+		const encrypted = ref.startsWith('data://') && isProviderCredentialEnvelope(serialized);
+		const value = encrypted ? await decryptProviderCredential(ref, serialized) : serialized;
 		if (!value) throw new Error(`Provider secret file ${path} is empty.`);
+		if (ref.startsWith('data://') && !encrypted) {
+			const temporary = `${path}.${process.pid}.${Date.now()}.migration`;
+			await writeFile(temporary, await encryptProviderCredential(ref, value), { encoding: 'utf8', mode: 0o600, flag: 'wx' });
+			await rename(temporary, path); await chmod(path, 0o600);
+		}
 		return value;
 	}
 	const resolved = await input.resolver?.(ref);
@@ -123,7 +133,8 @@ export async function stageProviderSecret(ref: string, value: string, baseDirect
 	const path = secretReferencePath(ref, baseDirectory, dataDirectory);
 	await mkdir(dirname(path), { recursive: true, mode: 0o700 });
 	const temporary = `${path}.${process.pid}.${Date.now()}.pending`;
-	await writeFile(temporary, `${value.trim()}\n`, { encoding: 'utf8', mode: 0o600, flag: 'wx' });
+	const serialized = ref.startsWith('data://') ? await encryptProviderCredential(ref, value.trim()) : `${value.trim()}\n`;
+	await writeFile(temporary, serialized, { encoding: 'utf8', mode: 0o600, flag: 'wx' });
 	await chmod(temporary, 0o600);
 	return {
 		path,

--- a/src/provider/coordination/coordinator.ts
+++ b/src/provider/coordination/coordinator.ts
@@ -1,6 +1,6 @@
 import { createHash, randomUUID } from 'node:crypto';
 import type {
-	CapacityProviderManifestV3,
+	CapacityProviderManifest,
 	CapacityProviderJoinInput,
 	ProviderAccessTokenIssue,
 	ProviderConnectionConfig,
@@ -59,7 +59,7 @@ interface CoordinatorIdentity {
 	publicJwk: Awaited<ReturnType<typeof loadCapacityProviderIdentity>>['publicJwk'];
 }
 
-function unsignedRegistration(manifest: CapacityProviderManifestV3, connection: CapacityProviderJoinInput, identity: CoordinatorIdentity) {
+function unsignedRegistration(manifest: CapacityProviderManifest, connection: CapacityProviderJoinInput, identity: CoordinatorIdentity) {
 	return {
 		schemaVersion: 1 as const,
 		displayName: manifest.identity.displayName,

--- a/src/provider/execution/codex-chat-executor.ts
+++ b/src/provider/execution/codex-chat-executor.ts
@@ -1,11 +1,112 @@
 import { spawn } from 'node:child_process';
-import { copyFile, mkdir, mkdtemp, readFile, rm } from 'node:fs/promises';
-import { join } from 'node:path';
+import { createHash } from 'node:crypto';
+import { chmod, chown, copyFile, mkdir, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
+import { join, posix } from 'node:path';
 import { tmpdir } from 'node:os';
+import { validateContentFrontmatter } from '@treeseed/sdk/content-validation';
 import type { AgentExecutionRequest, AgentExecutorModule } from './contracts.ts';
 
 const record = (value: unknown): Record<string, unknown> => value && typeof value === 'object' && !Array.isArray(value) ? value as Record<string, unknown> : {};
 const text = (value: unknown) => typeof value === 'string' ? value.trim() : '';
+const contentText = (value: unknown) => typeof value === 'string' ? value : '';
+const contentMetadata = (path: string, content: string) => ({ path, bytes: Buffer.byteLength(content), digest: `sha256:${createHash('sha256').update(content).digest('hex')}` });
+function secretValues(value: unknown): string[] {
+	if (typeof value === 'string') return value.length >= 16 ? [value] : [];
+	if (Array.isArray(value)) return value.flatMap(secretValues);
+	return value && typeof value === 'object' ? Object.values(value as Record<string, unknown>).flatMap(secretValues) : [];
+}
+function assertNoKnownSecret(value: unknown, secrets: string[]) {
+	const serialized = typeof value === 'string' ? value : JSON.stringify(value);
+	if (secrets.some((secret) => serialized.includes(secret))) throw new Error('Execution output contained a known credential fingerprint and was quarantined.');
+}
+
+export function assertObjectiveContentModel(path: string, file: Record<string, unknown>) {
+	if (!/(?:^|\/)objectives\/[^/]+\.(?:md|mdx)$/u.test(path)) return;
+	if (file.frontmatterError) throw new Error(`TreeDX objective is not valid Astro content: ${path}: ${String(file.frontmatterError)}`);
+	const validation = validateContentFrontmatter('objective', record(file.frontmatter));
+	if (!validation.ok) throw new Error(`TreeDX objective does not satisfy the SDK objective content model: ${path}: ${validation.diagnostics.map((item) => `${item.field}: ${item.message}`).join('; ')}`);
+}
+
+function command(executable: string, args: string[], cwd?: string) {
+	return new Promise<string>((resolve, reject) => {
+		const child = spawn(executable, args, { cwd, env: { ...process.env, GIT_TERMINAL_PROMPT: '0' }, stdio: ['ignore', 'pipe', 'pipe'] });
+		let stdout = '', stderr = '';
+		child.stdout.setEncoding('utf8'); child.stdout.on('data', (chunk) => { stdout += String(chunk); });
+		child.stderr.setEncoding('utf8'); child.stderr.on('data', (chunk) => { stderr = `${stderr}${chunk}`.slice(-16_000); });
+		child.once('error', reject); child.once('exit', (code) => code === 0 ? resolve(stdout.trim()) : reject(new Error(`${executable} exited ${code}: ${stderr.trim()}`)));
+	});
+}
+
+export function readableCloneUrl(value: string) {
+	const github = /^git@github\.com:([^/]+\/.+?)(?:\.git)?$/u.exec(value);
+	return github ? `https://github.com/${github[1]}.git` : value;
+}
+
+export async function prepareProjectWorkspace(assignment: Record<string, unknown>, workspace: string) {
+	const project = record(record(assignment.workspaceContext).project), repository = record(project.repository);
+	const cloneUrl = readableCloneUrl(text(repository.cloneUrl)); const branch = text(repository.currentBranch) || text(repository.defaultBranch) || 'staging';
+	if (!cloneUrl) throw new Error('Conversation assignment omitted its project source repository checkout authority.');
+	await command('git', ['clone', '--depth', '1', '--single-branch', '--branch', branch, cloneUrl, workspace]);
+	const revision = await command('git', ['rev-parse', 'HEAD'], workspace);
+	const tree = await command('git', ['ls-tree', '-rl', revision], workspace);
+	const entries = tree.split('\n').filter(Boolean).map((line) => /^(\d+)\s+(blob|commit)\s+([0-9a-f]+)(?:\s+(\d+))?\t(.+)$/u.exec(line));
+	if (entries.some((entry) => !entry || entry[2] !== 'blob' || !['100644', '100755'].includes(entry[1]!))) throw new Error('Project snapshot contains a symbolic link, submodule, or unsupported Git object mode.');
+	const files = entries.map((match) => ({ path: match![5]!, bytes: Number(match![4]), gitBlob: match![3]!, mode: match![1]! }));
+	return { projectId: text(project.id), projectSlug: text(project.slug), cloneUrl, branch, revision, root: workspace, fileCount: files.length, files };
+}
+
+export function validatedSnapshotPaths(entries: Record<string, unknown>[]) {
+	if (entries.length > 20_000) throw new Error('TreeDX snapshot exceeds the assignment file-count limit.');
+	const paths = entries.map((entry) => text(entry.path));
+	for (const path of paths) if (!path || path.length > 4_096 || path.startsWith('/') || path.includes('\\') || path.includes('\0') || posix.normalize(path) !== path || path.split('/').some((part) => !part || part === '.' || part === '..')) throw new Error(`TreeDX snapshot contains an unsafe content path: ${path || '<empty>'}`);
+	const unique = new Set(paths); if (unique.size !== paths.length) throw new Error('TreeDX snapshot contains duplicate content paths.');
+	for (const path of paths) { const parts = path.split('/'); for (let index = 1; index < parts.length; index += 1) if (unique.has(parts.slice(0, index).join('/'))) throw new Error(`TreeDX snapshot path collides with a parent file: ${path}`); }
+	return paths;
+}
+
+function resultPayload(value: unknown) {
+	const envelope = record(value), data = record(envelope.data ?? envelope), result = record(data.result ?? data);
+	return record(result.data ?? result);
+}
+
+async function retryTreeDx<T>(operation: () => Promise<T>, attempts = 3) {
+	let failure: unknown;
+	for (let attempt = 1; attempt <= attempts; attempt += 1) try { return await operation(); } catch (error) {
+		failure = error;
+		if (attempt < attempts) await new Promise((resolve) => setTimeout(resolve, attempt * 150));
+	}
+	throw failure;
+}
+
+export async function materializeTreeDxSnapshot(request: AgentExecutionRequest, destination: string) {
+	if (!request.treeDx.repositoryId || !request.treeDx.baseRef) throw new Error('Conversation assignment omitted its TreeDX repository or immutable ref.');
+	let cursor = '', entries: Record<string, unknown>[] = [];
+	do {
+		const payload = resultPayload(await retryTreeDx(() => request.treeDx.invoke('treedx.repositories.paths.list', { path: { repoId: request.treeDx.repositoryId }, body: {
+			ref: request.treeDx.baseRef, paths: ['**'], kinds: ['blob'], limit: 500, ...(cursor ? { cursor } : {}),
+		} })));
+		entries.push(...(Array.isArray(payload.entries) ? payload.entries.map(record) : []));
+		cursor = text(record(payload.page).nextCursor) || text(payload.nextCursor);
+	} while (cursor);
+	const paths = validatedSnapshotPaths(entries);
+	await mkdir(destination, { recursive: true, mode: 0o755 });
+	const files: Array<{ path: string; bytes: number; digest: string }> = [];
+	for (let index = 0; index < paths.length; index += 10) {
+		const selected = paths.slice(index, index + 10); const payload = resultPayload(await retryTreeDx(() => request.treeDx.invoke('treedx.repositories.files.read', {
+			path: { repoId: request.treeDx.repositoryId }, body: { ref: request.treeDx.baseRef, paths: selected, encoding: 'utf8', parseFrontmatter: true, allowProtected: true },
+		})));
+		const returned = Array.isArray(payload.files) ? payload.files.map(record) : [];
+		if (returned.length !== selected.length || new Set(returned.map((file) => text(file.path))).size !== selected.length) throw new Error('TreeDX snapshot read did not return every requested file exactly once.');
+		for (const file of returned) {
+			const path = text(file.path); if (!selected.includes(path)) continue; const target = join(destination, ...path.split('/'));
+			assertObjectiveContentModel(path, file);
+			const content = contentText(file.content) || contentText(file.body);
+			await mkdir(join(target, '..'), { recursive: true, mode: 0o755 }); await writeFile(target, content, { encoding: 'utf8', mode: 0o444 });
+			files.push(contentMetadata(path, content));
+		}
+	}
+	return { projectId: request.treeDx.projectId, repositoryId: request.treeDx.repositoryId, immutableRef: request.treeDx.baseRef, root: destination, fileCount: files.length, files };
+}
 
 export function discussionMessageSourcePaths(assignment: Record<string, unknown>) {
 	return Array.isArray(assignment.sourceMessageRefs)
@@ -14,6 +115,10 @@ export function discussionMessageSourcePaths(assignment: Record<string, unknown>
 }
 
 export async function readDiscussionSourceMessage(request: AgentExecutionRequest) {
+	return (await readDiscussionSourceContext(request)).content;
+}
+
+export async function readDiscussionSourceContext(request: AgentExecutionRequest) {
 	const repoId = request.treeDx.repositoryId; const paths = discussionMessageSourcePaths(request.assignment);
 	if (!repoId || !paths.length) throw new Error('Communication assignment omitted its TreeDX source message reference.');
 	const envelope = record(await request.treeDx.invoke('treedx.repositories.files.read', {
@@ -22,25 +127,74 @@ export async function readDiscussionSourceMessage(request: AgentExecutionRequest
 	}));
 	const data = record(envelope.data ?? envelope); const result = record(data.result ?? data);
 	const payload = record(result.data ?? result); const files = Array.isArray(payload.files) ? payload.files.map(record) : [];
-	const content = text(files[0]?.content) || text(files[0]?.body);
+	const content = contentText(files[0]?.content) || contentText(files[0]?.body);
 	if (!content) throw new Error('TreeDX did not return the assignment source message.');
-	return content;
+	return { kind: 'discussion-message', source: 'treedx', disposition: 'prompt-injected', immutableRef: request.treeDx.baseRef, ...contentMetadata(paths[0], content), content };
 }
 
-function run(executable: string, args: string[], input: string, environment: NodeJS.ProcessEnv, signal?: AbortSignal) {
+function run(executable: string, args: string[], input: string, environment: NodeJS.ProcessEnv, onEvent: (event: Record<string, unknown>) => Promise<void>, signal?: AbortSignal, identity?: { uid: number; gid: number }) {
 	return new Promise<void>((resolve, reject) => {
-		const child = spawn(executable, args, { env: environment, stdio: ['pipe', 'ignore', 'pipe'] });
-		let error = '';
+		const child = spawn(executable, args, { env: environment, stdio: ['pipe', 'pipe', 'pipe'], ...identity });
+		let error = '', output = '', events = Promise.resolve();
+		child.stdout.setEncoding('utf8'); child.stdout.on('data', (chunk) => {
+			output += String(chunk); const lines = output.split('\n'); output = lines.pop() ?? '';
+			for (const line of lines) if (line.trim()) events = events.then(async () => { try { await onEvent(record(JSON.parse(line))); } catch { await onEvent({ type: 'provider.event.invalid', rawDigest: createHash('sha256').update(line).digest('hex') }); } });
+		});
 		child.stderr.setEncoding('utf8'); child.stderr.on('data', (chunk) => { error = `${error}${chunk}`.slice(-16_000); });
 		const abort = () => child.kill('SIGTERM');
 		if (signal?.aborted) abort(); else signal?.addEventListener('abort', abort, { once: true });
 		child.once('error', reject);
-		child.once('exit', (code, exitSignal) => {
+		child.once('exit', async (code, exitSignal) => {
 			signal?.removeEventListener('abort', abort);
+			if (output.trim()) try { await onEvent(record(JSON.parse(output))); } catch { /* terminal partial output is represented by the exit status */ }
+			await events;
 			if (code === 0) resolve(); else reject(new Error(`Codex chat executor exited (${code ?? exitSignal ?? 'unknown'}): ${error.trim()}`));
 		});
 		child.stdin.end(input);
 	});
+}
+
+export async function readIdentityContext(request: AgentExecutionRequest, availablePaths?: ReadonlySet<string>) {
+	const metadata = record(request.assignment.metadata); const manifest = record(metadata.identityManifest);
+	const profile = record(manifest.agentProfile); const objective = record(manifest.coreObjective); const readme = record(manifest.projectReadme);
+	const profilePath = text(profile.path); const objectiveLogicalPath = text(objective.path);
+	const objectiveCandidates = [...new Set([...(Array.isArray(objective.candidates) ? objective.candidates.map(String) : []), ...(Array.isArray(objective.paths) ? objective.paths.map(String) : []), ...(!Array.isArray(objective.candidates) && !Array.isArray(objective.paths) && objectiveLogicalPath ? [objectiveLogicalPath] : [])].filter(Boolean))];
+	const objectivePaths = availablePaths ? objectiveCandidates.filter((path) => availablePaths.has(path)).slice(0, 1) : objectiveCandidates;
+	const readmePaths = [...new Set([text(readme.path), ...(Array.isArray(readme.paths) ? readme.paths.map(String) : [])].filter(Boolean))];
+	const templates = Array.isArray(manifest.instructionTemplates) ? manifest.instructionTemplates.map(record) : [];
+	const templatePaths = templates.map((entry) => text(entry.path)).filter(Boolean);
+	const paths = [...new Set([profilePath, ...objectivePaths, ...readmePaths, ...templatePaths].filter(Boolean))];
+	if (!request.treeDx.repositoryId || !text(manifest.agentHandle) || !profilePath || !objectivePaths.length) throw new Error('Conversation assignment omitted its immutable agent identity manifest.');
+	if (text(manifest.repositoryId) !== request.treeDx.repositoryId || !request.treeDx.baseRef || text(manifest.immutableRef) !== request.treeDx.baseRef)
+		throw new Error('Conversation assignment identity does not match its assignment-scoped TreeDX repository and immutable ref.');
+	const expectedRevisions = [text(profile.expectedRevision), text(objective.expectedRevision), text(readme.expectedRevision), ...templates.map((entry) => text(entry.expectedRevision))].filter(Boolean);
+	if (expectedRevisions.some((revision) => revision !== request.treeDx.baseRef)) throw new Error('Conversation assignment identity source revision is stale or mismatched.');
+	const envelope = record(await request.treeDx.invoke('treedx.repositories.files.read', { path: { repoId: request.treeDx.repositoryId }, body: {
+		...(request.treeDx.baseRef ? { ref: request.treeDx.baseRef } : {}), paths, encoding: 'utf8', parseFrontmatter: true, allowProtected: true,
+	} }));
+	const data = record(envelope.data ?? envelope); const result = record(data.result ?? data); const payload = record(result.data ?? result);
+	const files = (Array.isArray(payload.files) ? payload.files : []).map(record); const byPath = new Map(files.map((file) => [text(file.path), contentText(file.content) || contentText(file.body)]));
+	const fileByPath = new Map(files.map((file) => [text(file.path), file]));
+	const profileContent = byPath.get(profilePath) ?? ''; const objectiveEntry = objectivePaths.map((path) => [path, byPath.get(path) ?? ''] as const).find((entry) => entry[1]);
+	const readmeSources = readmePaths.map((path) => ({ kind: 'project-readme', path, content: byPath.get(path) ?? '' }));
+	const templateSources = templatePaths.map((path) => ({ kind: 'instruction-template', path, content: byPath.get(path) ?? '' }));
+	if (!profileContent || !objectiveEntry || readmeSources.some((source) => !source.content) || templateSources.some((source) => !source.content)) throw new Error('TreeDX identity verification requires the exact agent profile, logical objectives/core content, configured project README, and instruction templates.');
+	assertObjectiveContentModel(objectiveEntry[0], fileByPath.get(objectiveEntry[0]) ?? {});
+	const sources = [{ kind: 'agent-profile', path: profilePath, content: profileContent }, { kind: 'core-objective', logicalPath: objectiveLogicalPath || objectiveEntry[0].replace(/\.(?:mdx|md)$/u, ''), path: objectiveEntry[0], content: objectiveEntry[1] }, ...readmeSources, ...templateSources]
+		.map((source) => ({ ...source, source: 'treedx', disposition: 'prompt-injected', immutableRef: text(manifest.immutableRef), ...contentMetadata(source.path, source.content) }));
+	const expectedDigests = new Map<string, string>();
+	if (text(profile.digest)) expectedDigests.set(profilePath, text(profile.digest));
+	for (const entry of templates) if (text(entry.path) && text(entry.digest)) expectedDigests.set(text(entry.path), text(entry.digest));
+	for (const source of sources) if (expectedDigests.has(source.path) && expectedDigests.get(source.path) !== source.digest) throw new Error(`TreeDX identity source digest mismatch: ${source.path}`);
+	const verifiedManifest: Record<string, unknown> = { ...manifest, sources: sources.map(({ content: _content, ...source }) => source) };
+	return { manifest: verifiedManifest, sources };
+}
+
+function publicProviderEvent(event: Record<string, unknown>) {
+	const item = record(event.item); const usage = record(event.usage);
+	return { providerEventType: text(event.type) || 'unknown', itemType: text(item.type) || null, itemId: text(item.id) || null,
+		...(Object.keys(usage).length ? { usage, usageProvenance: 'execution-provider' } : {}),
+		...(typeof event.model === 'string' ? { model: event.model } : {}) };
 }
 
 export const createAgentExecutor: AgentExecutorModule['createAgentExecutor'] = async ({ executionProviderId }) => ({
@@ -57,21 +211,39 @@ export const createAgentExecutor: AgentExecutorModule['createAgentExecutor'] = a
 		if (!executable || !authFile) return { status: 'returned', code: 'codex_runtime_unavailable', summary: 'Trusted Codex executable or authentication custody is unavailable.', retryable: true };
 		const started = Date.now(); const root = await mkdtemp(join(tmpdir(), 'treeseed-codex-chat-'));
 		try {
-			const codexHome = join(root, 'codex'); const workspace = join(root, 'workspace'); const output = join(root, 'response.md');
-			await mkdir(codexHome, { mode: 0o700 }); await mkdir(workspace, { mode: 0o700 }); await copyFile(authFile, join(codexHome, 'auth.json'));
-			const message = await readDiscussionSourceMessage(request); const agent = text(request.assignment.agentId) || 'project-agent';
-			const metadata = record(request.assignment.metadata); const profile = record(metadata.chatProfile); const identity = record(profile.identity);
+			const codexUid = 65_534, codexGid = 65_534; const codexHome = join(root, 'codex'); const workspace = join(root, 'workspace'); const output = join(codexHome, 'response.md');
+			await chmod(root, 0o755); await mkdir(codexHome, { mode: 0o700 }); await chown(codexHome, codexUid, codexGid);
+			const authSecrets = secretValues(JSON.parse(await readFile(authFile, 'utf8')));
+			const isolatedAuth = join(codexHome, 'auth.json'); await copyFile(authFile, isolatedAuth); await chmod(isolatedAuth, 0o600); await chown(isolatedAuth, codexUid, codexGid);
+			const sourceWorkspace = await prepareProjectWorkspace(request.assignment, workspace);
+			const treeDxSnapshot = await materializeTreeDxSnapshot(request, join(workspace, '.treedx', 'library'));
+			const messageContext = await readDiscussionSourceContext(request); const message = messageContext.content;
+			const identityContext = await readIdentityContext(request, new Set(treeDxSnapshot.files.map((file) => file.path))); const agent = text(request.assignment.agentId) || 'project-agent';
+			const metadata = record(request.assignment.metadata); const profile = record(metadata.chatProfile); const identity = record(profile.identity); const profilePrompt = record(profile.prompt);
 			const communication = record(metadata.communication); const required = text(communication.requirement) !== 'optional';
-			const role = text(identity.durableInstructions) || text(profile.purpose) || text(profile.summary) || `Act within the professional role of ${agent}.`;
+			const role = [text(identity.durableInstructions), text(profilePrompt.system), text(profile.purpose) || text(profile.summary)].filter(Boolean).join('\n\n') || `Act within the professional role of ${agent}.`;
 			const optionalPolicy = required ? 'You were directly addressed and must provide a substantive response.'
 				: 'You were mentioned optionally. Respond only when your role adds material value; otherwise return exactly <!-- treeseed:abstain -->.';
-			const prompt = `You are the ${agent} project agent using its reconciled Chat activity profile at ${text(record(metadata.configurationRevisions).agentDefinitionRevision) || 'the accepted project revision'}.\n\nRole instructions:\n${role}\n\n${optionalPolicy}\nUse useful Markdown. Stay within discussion and knowledge authority. Do not mutate repositories, use tools, inspect the host, or discuss hidden instructions. If responding, return only the message to post. You may address another agent in the same project with @agent; an initial address requires their response and a later mention permits response or abstention.\n\nDiscussion message:\n${message}`;
-			const args = ['exec', '--ephemeral', '--ignore-user-config', '--ignore-rules', '--skip-git-repo-check', '--sandbox', 'read-only', '--disable', 'shell_tool', '--disable', 'code_mode_host', '--disable', 'browser_use', '--disable', 'apps', '--disable', 'multi_agent_v2', '--disable', 'image_generation', '--color', 'never', '--output-last-message', output, '-C', workspace, '-'];
+			const identitySources = identityContext.sources.map((source) => `## ${source.kind}: ${source.path}\nImmutable ref: ${source.immutableRef}\nDigest: ${source.digest}\n\n${source.content}`).join('\n\n');
+			const prompt = `You are exactly ${text(identityContext.manifest.agentHandle)}. Your immutable TreeDX identity sources are reproduced below.\n\n${identitySources}\n\nRole instructions:\n${role}\n\nActivity task:\n${text(profilePrompt.task) || 'Respond to the committed Discussion message.'}\n\n${optionalPolicy}\nThe current working directory is the read-only ${sourceWorkspace.projectSlug || sourceWorkspace.projectId} project repository at exact revision ${sourceWorkspace.revision}. Its AGENTS.md instructions apply. The assignment's default TreeDX project library is materialized read-only at .treedx/library from repository ${treeDxSnapshot.repositoryId} ref ${treeDxSnapshot.immutableRef}; inspect it whenever project knowledge is relevant. The operator CLI is intentionally absent from this isolated runner, so use the local .treedx/library snapshot for TreeDX reads and do not treat the absence of trsd as missing context. Use read-only repository tools to gather evidence before answering. Do not mutate repositories or inspect outside the assignment workspace. If responding, return only the message to post. Team discussion topics coordinate every project: use @project/agent for one exact agent, or @agent to address every chat-enabled agent with that handle across the team. An address in the initial address block requires a response; a later mention permits a response or abstention.\n\nDiscussion message:\n${message}`;
+			const execution = record(profile.execution); const model = text(execution.model); const capabilities = ['communication', 'repository-read', 'treedx-read', 'read-only-shell'];
+			const args = ['exec', '--json', '--ephemeral', '--ignore-user-config', '--dangerously-bypass-approvals-and-sandbox', ...(model ? ['--model', model] : []), '--enable', 'code_mode_host', '--disable', 'browser_use', '--disable', 'apps', '--disable', 'multi_agent_v2', '--disable', 'image_generation', '--color', 'never', '--output-last-message', output, '-C', workspace, '-'];
+			await request.emit?.({ type: 'execution.started', occurredAt: new Date().toISOString(), summary: `Execution started as ${text(identityContext.manifest.agentHandle)}.`,
+				payload: { model: model || null, capabilities, parameters: { sandbox: 'external-read-only-filesystem', tools: 'read-only', uid: codexUid }, identityManifest: identityContext.manifest,
+					contextManifest: [...identityContext.sources.map(({ content: _content, ...source }) => source), (({ content: _content, ...source }) => source)(messageContext),
+						{ kind: 'project-repository', source: 'git', disposition: 'tool-available', promptInjected: false, ...sourceWorkspace },
+						{ kind: 'treedx-library', source: 'treedx', disposition: 'tool-available', promptInjected: false, ...treeDxSnapshot }] }, protectedPayload: { prompt } });
+			const providerEvents: Record<string, unknown>[] = [];
 			await run(executable, args, prompt, { NODE_ENV: process.env.NODE_ENV, LANG: process.env.LANG, TZ: process.env.TZ,
-				HOME: workspace, CODEX_HOME: codexHome }, request.signal);
+				HOME: codexHome, CODEX_HOME: codexHome }, async (event) => { providerEvents.push(event); await request.emit?.({ type: `provider.${text(event.type) || 'event'}`, occurredAt: new Date().toISOString(),
+					summary: `Provider event: ${text(event.type) || 'event'}.`, payload: publicProviderEvent(event), protectedPayload: { providerEvent: event } }); }, request.signal, { uid: codexUid, gid: codexGid });
 			const markdown = (await readFile(output, 'utf8')).trim();
+			assertNoKnownSecret(markdown, authSecrets); assertNoKnownSecret(providerEvents, authSecrets);
 			if (!markdown) throw new Error('Codex returned an empty discussion response.');
-			const elapsedSeconds = Math.max(1, Math.ceil((Date.now() - started) / 1_000));
+			const elapsedSeconds = Math.max(1, Math.ceil((Date.now() - started) / 1_000)); const completed = [...providerEvents].reverse().find((event) => text(event.type).includes('completed')) ?? {};
+			const usage = record(completed.usage); await request.emit?.({ type: 'execution.completed', occurredAt: new Date().toISOString(), summary: `Execution completed as ${text(identityContext.manifest.agentHandle)}.`,
+				payload: { model: model || text(completed.model) || null, capabilities, usage: Object.keys(usage).length ? [{ ...usage, provenance: 'execution-provider' }] : [],
+					timing: { elapsedSeconds }, resources: { availability: 'partial', reason: 'child_cpu_and_peak_rss_unavailable' }, runtimeVersion: text(process.env.TREESEED_CODEX_VERSION) || null, parameters: { arguments: args.filter((value) => value !== workspace && value !== output) } } });
 			if (!required && markdown === '<!-- treeseed:abstain -->') return { status: 'abstained', summary: `Abstained as ${agent}.`,
 				usage: [{ usageDimension: 'aggregate', accountingMode: 'informational', activeSeconds: elapsedSeconds, elapsedSeconds }] };
 			return { status: 'responded', summary: `Responded as ${agent}.`, responseMarkdown: markdown,

--- a/src/provider/execution/contracts.ts
+++ b/src/provider/execution/contracts.ts
@@ -12,6 +12,7 @@ export interface AgentExecutionRequest {
   leaseToken: string;
   runnerId: string;
   treeDx: AssignmentTreeDxFacade;
+	emit?: (event: { type: string; occurredAt: string; summary: string; payload: Record<string, unknown>; protectedPayload?: Record<string, unknown> }) => Promise<void>;
   signal?: AbortSignal;
 }
 
@@ -37,6 +38,7 @@ export interface AgentExecutor {
   readonly id: string;
   observe(): Promise<AgentExecutorObservation>;
   execute(request: AgentExecutionRequest): Promise<AgentExecutionResult>;
+  renewLease?(assignmentId: string, leaseExpiresAt: string): Promise<void>;
   recover?(request: Pick<AgentExecutionRequest, 'assignment' | 'assignmentId' | 'runnerId'>): Promise<AgentExecutionResult | null>;
   shutdown?(): void | Promise<void>;
 }

--- a/src/provider/execution/executor-loader.ts
+++ b/src/provider/execution/executor-loader.ts
@@ -1,9 +1,10 @@
 import { pathToFileURL } from 'node:url';
 import { isAbsolute, resolve } from 'node:path';
-import type { CapacityProviderManifestV3 } from '@treeseed/sdk/capacity-provider';
+import type { CapacityProviderManifest, CapacityProviderManifestV3, CapacityProviderManifestV4 } from '@treeseed/sdk/capacity-provider';
 import type { ProviderHostRuntimeConfig } from '../configuration/config.ts';
 import type { AgentExecutor, AgentExecutorModule } from './contracts.ts';
 import { createProcessIsolatedExecutor } from './process-executor.ts';
+import { createMicrovmExecutor } from './microvm-executor.ts';
 
 const cache = new Map<string, Promise<AgentExecutorModule>>();
 
@@ -30,11 +31,12 @@ async function loadModule(specifier: string) {
   return module;
 }
 
-export async function resolveAgentExecutor(config: ProviderHostRuntimeConfig, adapter: CapacityProviderManifestV3['adapters'][number], manifest: CapacityProviderManifestV3): Promise<AgentExecutor | null> {
+export async function resolveAgentExecutor(config: ProviderHostRuntimeConfig, adapter: CapacityProviderManifest['adapters'][number], manifest: CapacityProviderManifest): Promise<AgentExecutor | null> {
   const module = adapter.module ?? config.executorModule;
   if (!module) return null;
   const specifier = executorModuleSpecifier(module);
-  if (adapter.isolation === 'process') return createProcessIsolatedExecutor(config, manifest, adapter, specifier);
+  if (adapter.isolation === 'microvm') return createMicrovmExecutor(config, manifest as CapacityProviderManifestV4, adapter as CapacityProviderManifestV4['adapters'][number]);
+  if (adapter.isolation === 'process') return createProcessIsolatedExecutor(config, manifest as CapacityProviderManifestV3, adapter as CapacityProviderManifestV3['adapters'][number], specifier);
   if ((adapter.credentialProfiles?.length ?? 0) > 0) throw new Error(`Worker-isolated adapter ${adapter.id} may not receive credential profiles.`);
   const executor = await (await loadModule(specifier)).createAgentExecutor({ executionProviderId: adapter.id, environment: config.environment });
   if (!executor || typeof executor.execute !== 'function' || typeof executor.observe !== 'function') {

--- a/src/provider/execution/microvm-executor.ts
+++ b/src/provider/execution/microvm-executor.ts
@@ -1,0 +1,79 @@
+import { createHash, createPrivateKey, sign } from 'node:crypto';
+import { dirname, resolve } from 'node:path';
+import type { CapacityProviderManifestV4, SandboxAssignment } from '@treeseed/sdk/capacity-provider';
+import { sandboxAssignmentSchema, sandboxLeaseRenewalSchema, sandboxResultSchema } from '@treeseed/sdk/capacity-provider';
+import type { ProviderHostRuntimeConfig } from '../configuration/config.ts';
+import { loadCapacityProviderIdentity } from '../accounts/identity.ts';
+import type { AgentExecutor } from './contracts.ts';
+import { SandboxBrokerClient } from './sandbox-broker-client.ts';
+import { materializeSandboxInputs } from './sandbox-input-materializer.ts';
+
+const canonical = (value: unknown): string => Array.isArray(value) ? `[${value.map(canonical).join(',')}]` : value && typeof value === 'object'
+	? `{${Object.entries(value as Record<string, unknown>).filter(([, item]) => item !== undefined).sort(([a], [b]) => a.localeCompare(b)).map(([key, item]) => `${JSON.stringify(key)}:${canonical(item)}`).join(',')}}` : JSON.stringify(value);
+const digest = (value: unknown) => `sha256:${createHash('sha256').update(canonical(value)).digest('hex')}`;
+
+export async function createMicrovmExecutor(config: ProviderHostRuntimeConfig, manifest: CapacityProviderManifestV4, adapter: CapacityProviderManifestV4['adapters'][number]): Promise<AgentExecutor> {
+	const client = new SandboxBrokerClient(manifest.sandbox.brokerSocket);
+	const identity = await loadCapacityProviderIdentity({ ref: manifest.identity.privateKeyRef, baseDirectory: config.manifestPath ? dirname(resolve(config.manifestPath)) : process.cwd(), dataDirectory: config.dataDir, env: process.env });
+	const signingKey = createPrivateKey({ key: identity.privateJwk as never, format: 'jwk' }), keyId = `provider-${createHash('sha256').update(identity.publicJwk.x).digest('hex').slice(0, 16)}`;
+	const active = new Map<string, { sandboxId: string; operationToken: string; providerId: string; teamId: string }>();
+	return {
+		id: adapter.id,
+		async renewLease(assignmentId, leaseExpiresAt) {
+			const current = active.get(assignmentId); if (!current) return;
+			const unsigned = { schemaVersion: 'treeseed.sandbox-lease-renewal/v1' as const, sandboxId: current.sandboxId, assignmentId, providerId: current.providerId, teamId: current.teamId, leaseExpiresAt, issuedAt: new Date().toISOString() };
+			const renewal = sandboxLeaseRenewalSchema.parse({ ...unsigned, signature: { keyId, algorithm: 'Ed25519', value: sign(null, Buffer.from(canonical(unsigned)), signingKey).toString('base64url') } });
+			await client.renew(current.sandboxId, current.operationToken, renewal);
+		},
+		async observe() {
+			try { const status = await client.status(); return { available: status.ready === true, capabilities: adapter.capabilities ?? [], reason: status.ready === true ? undefined : String(status.reason ?? 'sandbox_broker_unavailable') }; }
+			catch (error) { return { available: false, capabilities: adapter.capabilities ?? [], reason: error instanceof Error ? error.message : String(error) }; }
+		},
+		async execute(request) {
+			const metadata = request.assignment.metadata && typeof request.assignment.metadata === 'object' ? request.assignment.metadata as Record<string, unknown> : {};
+			const profileId = String(metadata.sandboxProfile ?? (request.assignment.executionKind === 'conversation' ? 'read' : 'unit'));
+			const profile = manifest.sandbox.profiles.find((entry) => entry.id === profileId && (adapter.sandboxProfileIds ?? []).includes(entry.id));
+			if (!profile) return { status: 'returned', code: 'sandbox_profile_unavailable', summary: `Sandbox profile ${profileId} is unavailable.`, retryable: true };
+			const materialized = await materializeSandboxInputs(request, profile.id !== 'read');
+			try {
+				const unsigned = { schemaVersion: 'treeseed.sandbox-assignment/v1', assignmentId: request.assignmentId, attempt: Math.max(1, Number(request.assignment.attemptCount ?? 1)), runnerId: request.runnerId,
+				providerId: String(request.assignment.capacityProviderId ?? request.assignment.capacity_provider_id ?? ''), teamId: String(request.assignment.teamId ?? request.assignment.team_id ?? ''), projectId: String(request.assignment.projectId ?? request.assignment.project_id ?? ''),
+				profile: profile.id, guestImage: profile.guestImage, guestImageDigest: profile.guestImageDigest,
+				identityManifestDigest: digest(materialized.identityManifest), contextManifestDigest: materialized.contextManifestDigest, resources: { ...profile.resources, durationSeconds: Math.max(60, Number(request.assignment.leaseSeconds ?? 300)) },
+				inputs: materialized.inputs.map(({ sourcePath: _sourcePath, ...input }) => input), outputs: [
+					{ id: 'result', path: '/run/treeseed-output/result.json', mediaType: 'application/json', maxBytes: profile.resources.outputBytes },
+					...(profile.id === 'read' ? [] : [{ id: 'project-patch', path: '/run/treeseed-output/project.patch', mediaType: 'application/vnd.treeseed.git-patch', maxBytes: profile.resources.outputBytes }]),
+				],
+				network: { defaultDeny: true as const, relayUrl: 'https://10.89.0.1:7443', allowedServices: ['model-gateway'], ...(profile.id === 'connected' && typeof metadata.developmentSessionId === 'string' ? { connectedDevelopmentSessionId: metadata.developmentSessionId } : {}) },
+				modelPolicy: { provider: 'openai', model: adapter.model?.model ?? 'gpt-5.4', capabilities: adapter.capabilities ?? [], ...(manifest.capacity.maxInputTokens ? { maxInputTokens: manifest.capacity.maxInputTokens } : {}), ...(manifest.capacity.maxOutputTokens ? { maxOutputTokens: manifest.capacity.maxOutputTokens } : {}), ...(manifest.capacity.maxCost ? { maxCost: manifest.capacity.maxCost } : {}) },
+				credentialHandles: (adapter.credentialProfiles ?? []).map((id) => ({ id, profileId: id, revealAllowed: false as const })), treeDxHandleIds: request.treeDx.workspaceId ? [request.treeDx.workspaceId] : [],
+				leaseExpiresAt: String(request.assignment.leaseExpiresAt ?? new Date(Date.now() + 300_000).toISOString()) };
+				const value = sign(null, Buffer.from(canonical(unsigned)), signingKey).toString('base64url');
+				const assignment = sandboxAssignmentSchema.parse({ ...unsigned, signature: { keyId, algorithm: 'Ed25519', value } }) as SandboxAssignment;
+				const prepared = await client.prepare(assignment, request.signal); active.set(request.assignmentId, { sandboxId: prepared.sandboxId, operationToken: prepared.operationToken, providerId: assignment.providerId, teamId: assignment.teamId }); let result; let artifacts: Record<string, unknown>[] = []; let teardown: Record<string, unknown> = { verified: false, completedAt: null };
+				await request.emit?.({ type: 'sandbox.created', occurredAt: new Date().toISOString(), summary: `Prepared Kata sandbox ${prepared.sandboxId}.`, payload: { sandboxId: prepared.sandboxId, profile: assignment.profile, guestImageDigest: assignment.guestImageDigest,
+					identityManifestDigest: assignment.identityManifestDigest, contextManifestDigest: assignment.contextManifestDigest, inputs: assignment.inputs.map(({ id, digest: inputDigest, bytes, disposition, mediaType, targetPath }) => ({ id, digest: inputDigest, bytes, disposition, mediaType, targetPath })) },
+					protectedPayload: { identityManifest: materialized.identityManifest, contextManifest: materialized.context } });
+				try {
+					for (const input of materialized.inputs) await client.upload(prepared.sandboxId, prepared.operationToken, input.id, input.sourcePath, input.bytes, request.signal);
+					await request.emit?.({ type: 'execution.started', occurredAt: new Date().toISOString(), summary: `Kata execution started in ${prepared.sandboxId}.`, payload: { sandboxId: prepared.sandboxId, model: assignment.modelPolicy.model, isolation: 'microvm' } });
+					result = sandboxResultSchema.parse(await client.execute(prepared.sandboxId, prepared.operationToken, {}, request.signal));
+					artifacts = await Promise.all(result.artifacts.map(async (artifact) => ({ ...artifact, content: (await client.downloadArtifact(prepared.sandboxId, prepared.operationToken, artifact.id, artifact.bytes, request.signal)).toString('utf8') })));
+				} finally {
+					const receipt = await client.destroy(prepared.sandboxId, prepared.operationToken).catch(() => null); teardown = receipt && typeof receipt.teardown === 'object' ? receipt.teardown as Record<string, unknown> : teardown;
+					active.delete(request.assignmentId);
+					await request.emit?.({ type: 'sandbox.destroyed', occurredAt: new Date().toISOString(), summary: `Kata sandbox ${prepared.sandboxId} teardown ${teardown.verified === true ? 'verified' : 'could not be verified'}.`, payload: { sandboxId: prepared.sandboxId, teardown } });
+				}
+				if (!result) throw new Error('Sandbox broker returned no assignment result.');
+				if (result.status === 'completed') {
+					const abstained = result.responseMarkdown?.trim() === '<!-- treeseed:abstain -->';
+					await request.emit?.({ type: 'execution.completed', occurredAt: new Date().toISOString(), summary: result.summary, payload: { sandboxId: result.sandboxId, model: assignment.modelPolicy.model, provider: assignment.modelPolicy.provider, capabilities: assignment.modelPolicy.capabilities,
+						usage: [result.usage], timing: { elapsedSeconds: result.usage.elapsedSeconds }, resources: { cpuUserMicros: result.usage.cpuUserMicros, cpuSystemMicros: result.usage.cpuSystemMicros, peakRssBytes: result.usage.peakRssBytes }, artifacts: result.artifacts, teardown }, protectedPayload: result.diagnostics });
+					return { status: abstained ? 'abstained' : result.responseMarkdown ? 'responded' : 'completed', summary: result.summary, ...(!abstained && result.responseMarkdown ? { responseMarkdown: result.responseMarkdown } : {}), outputs: { sandboxId: result.sandboxId, teardown }, artifacts, usage: [result.usage] };
+				}
+				await request.emit?.({ type: 'execution.failed', occurredAt: new Date().toISOString(), summary: result.summary, payload: { sandboxId: result.sandboxId, status: result.status, teardown }, protectedPayload: result.diagnostics });
+				return { status: result.status === 'failed' ? 'failed' : 'returned', code: `sandbox_${result.status}`, summary: result.summary, retryable: result.status !== 'failed', outputs: { sandboxId: result.sandboxId, teardown } };
+			} finally { await materialized.cleanup(); }
+		},
+	};
+}

--- a/src/provider/execution/process-executor-worker.ts
+++ b/src/provider/execution/process-executor-worker.ts
@@ -38,6 +38,10 @@ process.on('message', async (message: any) => {
 		if (message.ok) call.resolve(message.value); else call.reject(new Error(String(message.error)));
 		return;
 	}
+	if (message?.type === 'trace-result') {
+		const call = calls.get(String(message.callId)); if (!call) return;
+		calls.delete(String(message.callId)); if (message.ok) call.resolve(undefined); else call.reject(new Error(String(message.error))); return;
+	}
 	if (message?.type === 'cancel') return controllers.get(String(message.id))?.abort();
 	const id = String(message?.id ?? '');
 	try {
@@ -48,7 +52,10 @@ process.on('message', async (message: any) => {
 		if (message.type === 'execute') {
 			const controller = new AbortController(); controllers.set(id, controller);
 			const request = message.request;
-			const value = await executor.execute({ ...request, treeDx: treeDx(id, request.treeDx), signal: controller.signal });
+			const emit = (event: Record<string, unknown>) => new Promise<void>((resolve, reject) => {
+				const callId = `${id}:trace:${++callSequence}`; calls.set(callId, { resolve, reject }); process.send?.({ type: 'trace', requestId: id, callId, event });
+			});
+			const value = await executor.execute({ ...request, treeDx: treeDx(id, request.treeDx), emit, signal: controller.signal });
 			controllers.delete(id);
 			return process.send?.({ id, ok: true, value });
 		}

--- a/src/provider/execution/process-executor.ts
+++ b/src/provider/execution/process-executor.ts
@@ -45,6 +45,13 @@ export function createProcessIsolatedExecutor(config: ProviderHostRuntimeConfig,
 			} catch (error) { child.send({ type: 'treedx-result', callId: message.callId, ok: false, error: error instanceof Error ? error.message : String(error) }); }
 			return;
 		}
+		if (message?.type === 'trace') {
+			const request = pending.get(String(message.requestId))?.request;
+			if (!request?.emit) return child.send({ type: 'trace-result', callId: message.callId, ok: true });
+			try { await request.emit(message.event); child.send({ type: 'trace-result', callId: message.callId, ok: true }); }
+			catch (error) { child.send({ type: 'trace-result', callId: message.callId, ok: false, error: error instanceof Error ? error.message : String(error) }); }
+			return;
+		}
 		const id = String(message?.id ?? '');
 		const request = pending.get(id);
 		if (!request) return;

--- a/src/provider/execution/sandbox-broker-client.ts
+++ b/src/provider/execution/sandbox-broker-client.ts
@@ -1,0 +1,51 @@
+import { request } from 'node:http';
+import { createReadStream } from 'node:fs';
+import type { SandboxAssignment, SandboxLeaseRenewal, SandboxResult } from '@treeseed/sdk/capacity-provider';
+
+function call<T>(socketPath: string, method: string, path: string, body?: unknown, signal?: AbortSignal, headers: Record<string, string> = {}) {
+	return new Promise<T>((resolve, reject) => {
+		const encoded = body === undefined ? undefined : Buffer.from(JSON.stringify(body));
+		const operation = request({ socketPath, method, path, headers: { ...headers, ...(encoded ? { 'content-type': 'application/json', 'content-length': String(encoded.byteLength) } : {}) } }, (response) => {
+			let value = ''; response.setEncoding('utf8'); response.on('data', (chunk) => { value += chunk; });
+			response.on('end', () => {
+				let parsed: unknown; try { parsed = value ? JSON.parse(value) : {}; } catch { return reject(new Error('Sandbox broker returned invalid JSON.')); }
+				if ((response.statusCode ?? 500) >= 400) return reject(new Error(String((parsed as Record<string, unknown>).error ?? `Sandbox broker returned ${response.statusCode}.`)));
+				resolve(parsed as T);
+			});
+		});
+		operation.once('error', reject); const abort = () => operation.destroy(new Error('Sandbox broker request aborted.'));
+		if (signal?.aborted) abort(); else signal?.addEventListener('abort', abort, { once: true });
+		operation.once('close', () => signal?.removeEventListener('abort', abort)); if (encoded) operation.write(encoded); operation.end();
+	});
+}
+
+export class SandboxBrokerClient {
+	constructor(readonly socketPath: string) {}
+	private path(suffix: string) { return `/v${1}${suffix}`; }
+	status() { return call<Record<string, unknown>>(this.socketPath, 'GET', this.path('/status')); }
+	prepare(assignment: SandboxAssignment, signal?: AbortSignal) { return call<{ sandboxId: string; operationToken: string }>(this.socketPath, 'POST', this.path('/sandboxes'), { assignment }, signal); }
+	upload(sandboxId: string, token: string, inputId: string, sourcePath: string, bytes: number, signal?: AbortSignal) {
+		return new Promise<void>((resolve, reject) => {
+			const operation = request({ socketPath: this.socketPath, method: 'PUT', path: this.path(`/sandboxes/${encodeURIComponent(sandboxId)}/inputs/${encodeURIComponent(inputId)}`), headers: { authorization: `Bearer ${token}`, 'content-length': String(bytes), 'content-type': 'application/octet-stream' } }, (response) => {
+				let value = ''; response.setEncoding('utf8'); response.on('data', (chunk) => { value += chunk; }); response.on('end', () => (response.statusCode ?? 500) < 400 ? resolve() : reject(new Error(`Sandbox input upload failed: ${value.slice(0, 1_000)}`)));
+			});
+			operation.once('error', reject); const stream = createReadStream(sourcePath); stream.once('error', reject); stream.pipe(operation);
+			if (signal) signal.addEventListener('abort', () => { stream.destroy(); operation.destroy(new Error('Sandbox input upload aborted.')); }, { once: true });
+		});
+	}
+	execute(sandboxId: string, token: string, execution: Record<string, unknown>, signal?: AbortSignal) { return call<SandboxResult>(this.socketPath, 'POST', this.path(`/sandboxes/${encodeURIComponent(sandboxId)}/execute`), { execution }, signal, { authorization: `Bearer ${token}` }); }
+	renew(sandboxId: string, token: string, renewal: SandboxLeaseRenewal) { return call<Record<string, unknown>>(this.socketPath, 'POST', this.path(`/sandboxes/${encodeURIComponent(sandboxId)}/renew`), { renewal }, undefined, { authorization: `Bearer ${token}` }); }
+	downloadArtifact(sandboxId: string, token: string, artifactId: string, expectedBytes: number, signal?: AbortSignal) {
+		return new Promise<Buffer>((resolve, reject) => {
+			const chunks: Buffer[] = []; let bytes = 0;
+			const operation = request({ socketPath: this.socketPath, method: 'GET', path: this.path(`/sandboxes/${encodeURIComponent(sandboxId)}/artifacts/${encodeURIComponent(artifactId)}`), headers: { authorization: `Bearer ${token}` } }, (response) => {
+				if ((response.statusCode ?? 500) >= 400) { response.resume(); return reject(new Error(`Sandbox artifact download failed with ${response.statusCode}.`)); }
+				response.on('data', (chunk: Buffer) => { const value = Buffer.from(chunk); bytes += value.byteLength; if (bytes > expectedBytes) operation.destroy(new Error('Sandbox artifact exceeded its verified size.')); else chunks.push(value); });
+				response.on('end', () => bytes === expectedBytes ? resolve(Buffer.concat(chunks)) : reject(new Error('Sandbox artifact size changed during collection.')));
+			});
+			operation.once('error', reject); if (signal) signal.addEventListener('abort', () => operation.destroy(new Error('Sandbox artifact download aborted.')), { once: true }); operation.end();
+		});
+	}
+	cancel(sandboxId: string, token: string) { return call<Record<string, unknown>>(this.socketPath, 'POST', this.path(`/sandboxes/${encodeURIComponent(sandboxId)}/cancel`), undefined, undefined, { authorization: `Bearer ${token}` }); }
+	destroy(sandboxId: string, token: string) { return call<Record<string, unknown>>(this.socketPath, 'DELETE', this.path(`/sandboxes/${encodeURIComponent(sandboxId)}`), undefined, undefined, { authorization: `Bearer ${token}` }); }
+}

--- a/src/provider/execution/sandbox-input-materializer.ts
+++ b/src/provider/execution/sandbox-input-materializer.ts
@@ -1,0 +1,52 @@
+import { createHash } from 'node:crypto';
+import { createReadStream } from 'node:fs';
+import { mkdir, mkdtemp, rm, stat, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { spawn } from 'node:child_process';
+import type { SandboxAssignment } from '@treeseed/sdk/capacity-provider';
+import type { AgentExecutionRequest } from './contracts.ts';
+import { materializeTreeDxSnapshot, prepareProjectWorkspace, readDiscussionSourceContext, readIdentityContext } from './codex-chat-executor.ts';
+
+type Input = SandboxAssignment['inputs'][number] & { sourcePath: string };
+
+function archive(source: string, target: string, excludes: string[] = []) {
+	return new Promise<void>((accept, reject) => {
+		const child = spawn('/usr/bin/tar', ['--create', '--file', target, ...excludes.flatMap((value) => ['--exclude', value]), '--directory', source, '.'], { stdio: ['ignore', 'ignore', 'pipe'] });
+		let error = ''; child.stderr.setEncoding('utf8'); child.stderr.on('data', (chunk) => { error = `${error}${chunk}`.slice(-8_000); });
+		child.once('error', reject); child.once('exit', (code) => code === 0 ? accept() : reject(new Error(`Sandbox input archive failed (${code}): ${error}`)));
+	});
+}
+
+async function digest(path: string) {
+	const hash = createHash('sha256'); for await (const chunk of createReadStream(path)) hash.update(chunk as Buffer);
+	return `sha256:${hash.digest('hex')}`;
+}
+
+async function descriptor(id: string, sourcePath: string, targetPath: string, disposition: 'read-only' | 'copy-on-write', mediaType: string): Promise<Input> {
+	return { id, sourcePath, targetPath, disposition, mediaType, bytes: (await stat(sourcePath)).size, digest: await digest(sourcePath) };
+}
+
+export async function materializeSandboxInputs(request: AgentExecutionRequest, writableProject = false) {
+	const root = await mkdtemp(join(tmpdir(), 'treeseed-sandbox-inputs-')), project = join(root, 'project'), library = join(root, 'library');
+	try {
+		const projectManifest = await prepareProjectWorkspace(request.assignment, project);
+		const treeDxManifest = await materializeTreeDxSnapshot(request, library);
+		const identity = await readIdentityContext(request, new Set(treeDxManifest.files.map((file) => file.path)));
+		const message = await readDiscussionSourceContext(request);
+		const metadata = request.assignment.metadata && typeof request.assignment.metadata === 'object' && !Array.isArray(request.assignment.metadata) ? request.assignment.metadata as Record<string, unknown> : {};
+		const safeAssignment = { id: request.assignment.id ?? request.assignmentId, agentId: request.assignment.agentId ?? request.assignment.agent_id, executionKind: request.assignment.executionKind ?? request.assignment.execution_kind,
+			sourceMessageRefs: request.assignment.sourceMessageRefs, metadata: { identityManifest: metadata.identityManifest, chatProfile: metadata.chatProfile, communication: metadata.communication } };
+		const context = { schemaVersion: 1, assignment: safeAssignment, projectManifest: { ...projectManifest, root: '/workspace/project' }, treeDxManifest: { ...treeDxManifest, root: '/workspace/.treedx/library' }, identity, message };
+		const contextPath = join(root, 'context.json'); await writeFile(contextPath, `${JSON.stringify(context)}\n`, { mode: 0o400 });
+		const projectArchive = join(root, 'project.tar'), libraryArchive = join(root, 'library.tar');
+		await archive(project, projectArchive, ['.git']); await archive(library, libraryArchive);
+		const inputs = await Promise.all([
+			descriptor('project-repository', projectArchive, '/workspace/project', writableProject ? 'copy-on-write' : 'read-only', 'application/vnd.treeseed.directory+tar'),
+			descriptor('treedx-library', libraryArchive, '/workspace/.treedx/library', 'read-only', 'application/vnd.treeseed.directory+tar'),
+			descriptor('execution-context', contextPath, '/workspace/.treeseed/context.json', 'read-only', 'application/json'),
+			descriptor('relay-ca', '/etc/treeseed/sandbox/relay-ca.crt', '/workspace/.treeseed/relay-ca.crt', 'read-only', 'application/x-pem-file'),
+		]);
+		return { inputs, identityManifest: identity.manifest, context, contextManifestDigest: inputs.find((input) => input.id === 'execution-context')!.digest, async cleanup() { await rm(root, { recursive: true, force: true }); } };
+	} catch (error) { await rm(root, { recursive: true, force: true }); throw error; }
+}

--- a/src/provider/lifecycle/entrypoint.ts
+++ b/src/provider/lifecycle/entrypoint.ts
@@ -159,18 +159,20 @@ async function main() {
 		const teamId = String(input.teamId ?? '');
 		const loaded = await import('../configuration/manifest.ts').then(({ loadProviderManifest }) => loadProviderManifest(config.manifestPath!, config.dataDir));
 		if (!enrollmentToken || !teamId) throw new Error('Provider enrollment requires a team and one-time token.');
-		await import('../accounts/identity.ts').then(({ ensureCapacityProviderIdentity }) => ensureCapacityProviderIdentity({
+		const privateIdentity = await import('../accounts/identity.ts').then(({ ensureCapacityProviderIdentity }) => ensureCapacityProviderIdentity({
 			ref: loaded.manifest.identity.privateKeyRef,
 			baseDirectory: loaded.directory,
 			dataDirectory: config.dataDir,
 		}));
+		const publicJwk = privateIdentity.publicJwk;
+		const signingKeyId = `provider-${await import('node:crypto').then(({ createHash }) => createHash('sha256').update(publicJwk.x).digest('hex').slice(0, 16))}`;
 		const receipt = await coordinator.beginJoin({ id: connectionId,
 			...(input.serverProfile ? { serverProfile: String(input.serverProfile) } : { controlPlaneUrl: String(input.controlPlaneUrl ?? '') }),
 			controlPlaneAudience: String(input.controlPlaneAudience ?? input.controlPlaneUrl ?? ''), registrationKeyRef: 'memory://one-time',
 			offer: { maxConcurrentRunners: loaded.manifest.capacity.maxConcurrentWorkers,
 				capabilities: [...new Set(loaded.manifest.adapters.flatMap((adapter) => adapter.capabilities ?? []))],
 				metadata: { manifestGeneration: loaded.manifest.configuration.generation } } }, enrollmentToken);
-		emit({ ok: true, connectionId, status: receipt.status, teamId: receipt.teamId, providerId: receipt.providerId, requestId: receipt.requestId });
+		emit({ ok: true, connectionId, status: receipt.status, teamId: receipt.teamId, providerId: receipt.providerId, requestId: receipt.requestId, sandboxIdentity: { signingKeyId, publicJwk } });
 		return;
 	}
 	if (role === 'manager') {

--- a/src/provider/operations/runner.ts
+++ b/src/provider/operations/runner.ts
@@ -21,7 +21,7 @@ function text(...values: unknown[]) {
 }
 
 export interface ProviderAssignmentRunInput {
-  client: Pick<ProviderProtocolClient, 'renewAssignment' | 'startAssignmentExecution' | 'startAssignmentCloseout' | 'preflightAssignmentCompletion' | 'completeAssignment' | 'returnAssignment' | 'failAssignment' | 'reportAssignmentUsage' | 'respondToAssignmentDiscussion' | 'settleAssignment'>;
+  client: Pick<ProviderProtocolClient, 'renewAssignment' | 'startAssignmentExecution' | 'startAssignmentCloseout' | 'preflightAssignmentCompletion' | 'completeAssignment' | 'returnAssignment' | 'failAssignment' | 'reportAssignmentUsage' | 'respondToAssignmentDiscussion' | 'settleAssignment' | 'createCommunicationTraceEvent'>;
   executor: AgentExecutor;
   assignment: Record<string, unknown>;
   leaseToken: string;
@@ -92,10 +92,18 @@ export async function runProviderAssignment(input: ProviderAssignmentRunInput) {
     scheduleRenewal();
   };
   scheduleRenewal();
+	let traceSequence = 0;
   try {
-    result = await input.executor.execute({ assignment: executorAssignment(input.assignment), assignmentId, leaseToken: input.leaseToken, runnerId: input.runnerId, treeDx, signal: executionAbort.signal });
+    result = await input.executor.execute({ assignment: executorAssignment(input.assignment), assignmentId, leaseToken: input.leaseToken, runnerId: input.runnerId, treeDx,
+		emit: (event) => input.client.createCommunicationTraceEvent(assignmentId, { leaseToken: input.leaseToken, runnerId: input.runnerId, sequence: traceSequence++, ...event }).then(() => undefined),
+		signal: executionAbort.signal });
   } catch (error) {
-    result = { status: 'failed', code: 'agent_executor_failed', summary: error instanceof Error ? error.message : String(error), retryable: true };
+		const summary = error instanceof Error ? error.message : String(error);
+		if (text(input.assignment.executionKind, input.assignment.execution_kind) === 'conversation') {
+			await input.client.createCommunicationTraceEvent(assignmentId, { leaseToken: input.leaseToken, runnerId: input.runnerId, sequence: traceSequence++,
+				type: 'execution.failed', occurredAt: new Date().toISOString(), summary, payload: { code: 'agent_executor_failed', retryable: true } }).catch(() => undefined);
+		}
+    result = { status: 'failed', code: 'agent_executor_failed', summary, retryable: true };
   } finally {
     stopped = true;
     if (timer) clearTimeout(timer);

--- a/src/provider/security/credential-vault.ts
+++ b/src/provider/security/credential-vault.ts
@@ -1,0 +1,44 @@
+import { createHash } from 'node:crypto';
+import { readFile } from 'node:fs/promises';
+import { EncryptedEnvelopeCodec, StaticEnvelopeKeyProvider, encryptedEnvelopeSchema } from '@treeseed/sdk/security';
+
+function keyMaterial() {
+	const path = process.env.TREESEED_PROVIDER_CREDENTIAL_KEK_FILE ?? '/run/credentials/application-credential-kek';
+	return readFile(path).then((value) => value).catch((error: NodeJS.ErrnoException) => {
+		const environment = process.env.TREESEED_PROVIDER_ENVIRONMENT ?? process.env.TREESEED_ENVIRONMENT ?? 'development';
+		if (!['local', 'test', 'development'].includes(environment)) throw new Error(`Provider credential KEK is unavailable: ${error.code ?? 'read_failed'}`);
+		return Buffer.from(process.env.TREESEED_PROVIDER_CREDENTIAL_KEK ?? 'treeseed-development-provider-credential-kek');
+	});
+}
+
+async function codec() {
+	const material = await keyMaterial(), key = createHash('sha256').update(material).digest(); material.fill(0);
+	const historical = await Promise.all(String(process.env.TREESEED_PROVIDER_CREDENTIAL_HISTORICAL_KEY_FILES ?? '').split(',').map((entry) => entry.trim()).filter(Boolean).map(async (entry) => {
+		const match = /^(\d+):(.+)$/u.exec(entry); if (!match) throw new Error('Historical provider credential keys must use VERSION:/absolute/path entries.');
+		const value = await readFile(match[2]!); try { return { id: 'provider-credentials', version: Number(match[1]), key: createHash('sha256').update(value).digest() }; } finally { value.fill(0); }
+	}));
+	const provider = new StaticEnvelopeKeyProvider('systemd-credential', { id: 'provider-credentials', version: Number(process.env.TREESEED_PROVIDER_CREDENTIAL_KEY_VERSION ?? 1), key }, historical);
+	return new EncryptedEnvelopeCodec(provider);
+}
+
+const aad = (resourceId: string) => ({ purpose: 'provider-credential', teamId: 'provider-local', resourceType: 'provider-secret', resourceId, schemaVersion: 'treeseed.encrypted-envelope/v1' });
+
+export async function encryptProviderCredential(resourceId: string, plaintext: string) {
+	const value = (await codec()).encrypt(Buffer.from(plaintext), aad(resourceId));
+	return `${JSON.stringify(value)}\n`;
+}
+
+export async function decryptProviderCredential(resourceId: string, serialized: string) {
+	const parsed = encryptedEnvelopeSchema.safeParse(JSON.parse(serialized));
+	if (!parsed.success) throw new Error('Provider credential envelope is invalid.');
+	const plaintext = (await codec()).decrypt(parsed.data);
+	try { return plaintext.toString('utf8'); } finally { plaintext.fill(0); }
+}
+
+export async function rewrapProviderCredential(serialized: string) {
+	const parsed = encryptedEnvelopeSchema.parse(JSON.parse(serialized)); return `${JSON.stringify((await codec()).rewrap(parsed))}\n`;
+}
+
+export function isProviderCredentialEnvelope(serialized: string) {
+	try { return encryptedEnvelopeSchema.safeParse(JSON.parse(serialized)).success; } catch { return false; }
+}

--- a/src/provider/security/rewrap-vault.ts
+++ b/src/provider/security/rewrap-vault.ts
@@ -1,0 +1,31 @@
+import { lstat, readFile, readdir, rename, writeFile } from 'node:fs/promises';
+import { resolve } from 'node:path';
+import { encryptedEnvelopeSchema } from '@treeseed/sdk/security';
+import { rewrapProviderCredential } from './credential-vault.ts';
+
+async function candidates(root: string, relative = ''): Promise<string[]> {
+	const directory = resolve(root, relative), result: string[] = [];
+	for (const name of await readdir(directory)) {
+		const child = relative ? `${relative}/${name}` : name, path = resolve(root, child), information = await lstat(path);
+		if (information.isSymbolicLink()) throw new Error(`Credential vault contains an unsupported symbolic link: ${child}`);
+		if (information.isDirectory()) result.push(...await candidates(root, child)); else if (information.isFile() && information.size <= 1_048_576) result.push(path);
+	}
+	return result;
+}
+
+export async function rewrapProviderCredentialVault(root: string) {
+	let scanned = 0, rewrapped = 0;
+	for (const path of await candidates(resolve(root))) {
+		scanned += 1; const serialized = await readFile(path, 'utf8'); let parsed;
+		try { parsed = encryptedEnvelopeSchema.safeParse(JSON.parse(serialized)); } catch { continue; }
+		if (!parsed.success || parsed.data.aad.purpose !== 'provider-credential') continue;
+		const updated = await rewrapProviderCredential(serialized); if (updated === serialized) continue;
+		const temporary = `${path}.${process.pid}.rewrap`; await writeFile(temporary, updated, { mode: 0o600, flag: 'wx' }); await rename(temporary, path); rewrapped += 1;
+	}
+	return { scanned, rewrapped };
+}
+
+if (process.argv[1]?.endsWith('/rewrap-vault.js')) {
+	const root = process.argv[2]; if (!root) throw new Error('Provider credential vault root is required.');
+	process.stdout.write(`${JSON.stringify(await rewrapProviderCredentialVault(root))}\n`);
+}

--- a/src/provider/teams/multi-team-runtime.ts
+++ b/src/provider/teams/multi-team-runtime.ts
@@ -142,12 +142,21 @@ export async function runMultiTeamProviderRunners(
 				results.push({ connectionId: connection.connection.id, status: 'idle', reason: 'no_assignment' });
 				continue;
 			}
+			if (text(assignment.executionKind) === 'conversation') await client.acknowledgeCommunicationNotification(assignmentId, {
+				providerId: connection.providerId, runnerId: claim.runnerId, observedAt: new Date().toISOString(),
+			});
 			const executionProviderId = text(assignment.executionProviderId, record(assignment.capacityEnvelope).executionProviderId);
 			const laneId = text(assignment.laneId, record(assignment.capacityEnvelope).laneId);
 			const adapter = loaded.manifest.adapters.find((candidate) => candidate.id === executionProviderId && (!laneId || candidate.laneIds.includes(laneId)));
-			if (!adapter) { await localState.release(claim.id); results.push({ connectionId: connection.connection.id, status: 'idle', reason: 'assignment_adapter_unavailable' }); continue; }
+			if (!adapter) {
+				await client.returnAssignment(assignmentId, { leaseToken, runnerId: claim.runnerId, code: 'assignment_adapter_unavailable', reason: 'The assigned execution adapter is not installed on this provider.', retryable: true });
+				await localState.release(claim.id); results.push({ connectionId: connection.connection.id, status: 'idle', reason: 'assignment_adapter_unavailable' }); continue;
+			}
 			const executor = await resolveAgentExecutor(config, adapter, loaded.manifest);
-			if (!executor || !(await executor.observe()).available) { await localState.release(claim.id); results.push({ connectionId: connection.connection.id, status: 'idle', reason: 'executor_unavailable' }); continue; }
+			if (!executor || !(await executor.observe()).available) {
+				await client.returnAssignment(assignmentId, { leaseToken, runnerId: claim.runnerId, code: 'executor_unavailable', reason: 'The Kata sandbox host is not ready for this assignment.', retryable: true });
+				await localState.release(claim.id); results.push({ connectionId: connection.connection.id, status: 'idle', reason: 'executor_unavailable' }); continue;
+			}
 			const leaseExpiresAt = text(assignment.leaseExpiresAt) ?? new Date(Date.now() + 300_000).toISOString();
 			await localState.attachLease(claim.id, {
 				assignmentId,
@@ -166,10 +175,10 @@ export async function runMultiTeamProviderRunners(
 				leaseToken,
 				runnerId: claim.runnerId,
 				leaseSeconds: 300,
-				onLeaseRenewed: (renewedLeaseExpiresAt) => localState.renewLease(claim.id, {
-					assignmentId,
-					leaseExpiresAt: renewedLeaseExpiresAt,
-				}).then(() => undefined),
+				onLeaseRenewed: async (renewedLeaseExpiresAt) => {
+					await executor.renewLease?.(assignmentId, renewedLeaseExpiresAt);
+					await localState.renewLease(claim.id, { assignmentId, leaseExpiresAt: renewedLeaseExpiresAt });
+				},
 			});
 			await localState.finalize(claim.id, 'terminal-receipt-confirmed');
 			results.push({ connectionId: connection.connection.id, assignmentId, status: 'settled', terminal });

--- a/src/sandbox/guest.ts
+++ b/src/sandbox/guest.ts
@@ -1,0 +1,123 @@
+import { spawn } from 'node:child_process';
+import { createHash } from 'node:crypto';
+import { createReadStream } from 'node:fs';
+import { createServer } from 'node:http';
+import { request as httpsRequest } from 'node:https';
+import { chmod, mkdir, readFile, stat, writeFile } from 'node:fs/promises';
+import { dirname, resolve } from 'node:path';
+import { sandboxAssignmentSchema, sandboxResultSchema, type SandboxAssignment } from '@treeseed/sdk/capacity-provider';
+
+const inputRoot = '/run/treeseed-assignment';
+const outputRoot = '/run/treeseed-output';
+const workspaceRoot = '/workspace';
+const record = (value: unknown): Record<string, unknown> => value && typeof value === 'object' && !Array.isArray(value) ? value as Record<string, unknown> : {};
+const text = (value: unknown) => typeof value === 'string' ? value.trim() : '';
+const canonical = (value: unknown): string => Array.isArray(value) ? `[${value.map(canonical).join(',')}]` : value && typeof value === 'object'
+	? `{${Object.entries(value as Record<string, unknown>).filter(([, item]) => item !== undefined).sort(([a], [b]) => a.localeCompare(b)).map(([key, item]) => `${JSON.stringify(key)}:${canonical(item)}`).join(',')}}` : JSON.stringify(value);
+const objectDigest = (value: unknown) => `sha256:${createHash('sha256').update(canonical(value)).digest('hex')}`;
+
+async function fileDigest(path: string) {
+	const hash = createHash('sha256'); for await (const chunk of createReadStream(path)) hash.update(chunk as Buffer);
+	return `sha256:${hash.digest('hex')}`;
+}
+
+
+function run(executable: string, args: string[], options: { cwd?: string; input?: string; env?: NodeJS.ProcessEnv; onLine?: (line: string) => void; captureStdout?: boolean; maxStdoutBytes?: number } = {}) {
+	return new Promise<{ stderr: string; stdout: string }>((accept, reject) => {
+		const child = spawn(executable, args, { cwd: options.cwd, env: options.env, stdio: ['pipe', 'pipe', 'pipe'] }); let pending = '', stderr = '', stdout = '';
+		child.stdout.setEncoding('utf8'); child.stdout.on('data', (chunk) => {
+			const value = String(chunk);
+			if (options.captureStdout) { stdout += value; if (Buffer.byteLength(stdout) > (options.maxStdoutBytes ?? 8_388_608)) child.kill('SIGKILL'); }
+			pending += value; const lines = pending.split('\n'); pending = lines.pop() ?? ''; for (const line of lines) if (line.trim()) options.onLine?.(line);
+		});
+		child.stderr.setEncoding('utf8'); child.stderr.on('data', (chunk) => { stderr = `${stderr}${chunk}`.slice(-32_768); });
+		child.once('error', reject); child.once('exit', (code, signal) => { if (pending.trim()) options.onLine?.(pending); code === 0 ? accept({ stderr, stdout }) : reject(new Error(`${executable} exited ${code ?? signal}: ${stderr}`)); });
+		child.stdin.end(options.input ?? '');
+	});
+}
+
+async function materialize(assignment: SandboxAssignment) {
+	for (const descriptor of assignment.inputs) {
+		const source = resolve(inputRoot, `input-${descriptor.id}`), information = await stat(source);
+		if (information.size !== descriptor.bytes || await fileDigest(source) !== descriptor.digest) throw new Error(`Signed input failed guest verification: ${descriptor.id}`);
+		const target = resolve(descriptor.targetPath); if (!target.startsWith(`${workspaceRoot}/`)) throw new Error('Signed input target escaped the guest workspace.');
+		await mkdir(descriptor.mediaType.endsWith('+tar') ? target : dirname(target), { recursive: true, mode: 0o700 });
+		if (descriptor.mediaType === 'application/vnd.treeseed.directory+tar') await run('/bin/tar', ['--extract', '--file', source, '--directory', target, '--no-same-owner', '--no-same-permissions']);
+		else if (descriptor.mediaType === 'application/json' || descriptor.mediaType === 'application/x-pem-file') await writeFile(target, await readFile(source), { mode: descriptor.disposition === 'read-only' ? 0o400 : 0o600 });
+		else throw new Error(`Unsupported signed input media type: ${descriptor.mediaType}`);
+		if (descriptor.disposition === 'read-only') { await run('/bin/chmod', ['-R', 'a-w', target]); await chmod(target, 0o500); }
+	}
+}
+
+async function startModelRelay(assignment: SandboxAssignment, sandboxId: string, operationToken: string) {
+	const ca = await readFile('/workspace/.treeseed/relay-ca.crt');
+	const server = createServer((incoming, outgoing) => {
+		if (incoming.method !== 'POST' || incoming.url !== `/${'v1'}/responses`) { outgoing.writeHead(404); outgoing.end(); return; }
+		const url = new URL(assignment.network.relayUrl);
+		const upstream = httpsRequest({ hostname: url.hostname, port: Number(url.port), ca, servername: 'treeseed-sandbox-relay', method: 'POST', path: `/${'v1'}/sandboxes/${encodeURIComponent(sandboxId)}/model/responses`, headers: { ...incoming.headers, host: 'treeseed-sandbox-relay', authorization: `Bearer ${operationToken}` } }, (response) => {
+			outgoing.writeHead(response.statusCode ?? 502, response.headers); response.pipe(outgoing);
+		});
+		upstream.once('error', (error) => { if (!outgoing.headersSent) outgoing.writeHead(502, { 'content-type': 'application/json' }); outgoing.end(JSON.stringify({ error: error.message })); }); incoming.pipe(upstream);
+	});
+	await new Promise<void>((accept, reject) => { server.once('error', reject); server.listen(0, '127.0.0.1', accept); });
+	const address = server.address(); if (!address || typeof address === 'string') throw new Error('Guest model relay did not bind a TCP port.');
+	return { baseUrl: `http://127.0.0.1:${address.port}/${'v1'}`, close: () => new Promise<void>((accept, reject) => server.close((error) => error ? reject(error) : accept())) };
+}
+
+function promptFromContext(context: Record<string, unknown>) {
+	const identity = record(context.identity), manifest = record(identity.manifest), sources = Array.isArray(identity.sources) ? identity.sources.map(record) : [];
+	const assignment = record(context.assignment), metadata = record(assignment.metadata), chatProfile = record(metadata.chatProfile), prompt = record(chatProfile.prompt), communication = record(metadata.communication);
+	const sourceText = sources.map((source) => `## ${text(source.kind)}: ${text(source.path)}\nImmutable ref: ${text(source.immutableRef)}\nDigest: ${text(source.digest)}\n\n${text(source.content)}`).join('\n\n');
+	const required = text(communication.requirement) !== 'optional';
+	return `You are exactly ${text(manifest.agentHandle)}. Your verified immutable TreeDX identity sources follow.\n\n${sourceText}\n\nActivity task:\n${text(prompt.task) || 'Respond to the committed Discussion message.'}\n\n${required ? 'You were directly addressed and must provide a substantive response.' : 'Respond only if your role adds material value; otherwise return exactly <!-- treeseed:abstain -->.'}\nThe working directory is the exact project repository snapshot. The read-only TreeDX library is at /workspace/.treedx/library. Inspect repository files and AGENTS.md before answering. Do not inspect outside /workspace or disclose credentials. Return only the message to post.\n\nDiscussion message:\n${text(record(context.message).content)}`;
+}
+
+export async function runSandboxGuest() {
+	const started = process.hrtime.bigint(), usageBefore = process.resourceUsage();
+	const assignment = sandboxAssignmentSchema.parse(JSON.parse(await readFile(resolve(inputRoot, 'assignment.json'), 'utf8')));
+	const sandboxId = (await readFile(resolve(inputRoot, 'sandbox-id'), 'utf8')).trim(), operationToken = (await readFile(resolve(inputRoot, 'operation-token'), 'utf8')).trim();
+	await materialize(assignment); const context = record(JSON.parse(await readFile('/workspace/.treeseed/context.json', 'utf8')));
+	if (assignment.contextManifestDigest !== assignment.inputs.find((input) => input.id === 'execution-context')?.digest || assignment.identityManifestDigest !== objectDigest(record(record(context.identity).manifest))) throw new Error('Guest context or identity manifest does not match the signed assignment.');
+	const writableProject = assignment.inputs.some((input) => input.id === 'project-repository' && input.disposition === 'copy-on-write');
+	if (writableProject) {
+		await run('/usr/bin/git', ['init', '--quiet'], { cwd: '/workspace/project' });
+		await run('/usr/bin/git', ['config', 'user.name', 'TreeSeed Assignment Baseline'], { cwd: '/workspace/project' });
+		await run('/usr/bin/git', ['config', 'user.email', 'assignment-baseline@treeseed.invalid'], { cwd: '/workspace/project' });
+		await run('/usr/bin/git', ['add', '--all'], { cwd: '/workspace/project' });
+		await run('/usr/bin/git', ['commit', '--quiet', '--allow-empty', '-m', 'Immutable assignment baseline'], { cwd: '/workspace/project' });
+	}
+	const relay = await startModelRelay(assignment, sandboxId, operationToken);
+	const codexHome = '/workspace/.treeseed/codex', responsePath = '/workspace/.treeseed/response.md'; await mkdir(codexHome, { recursive: true, mode: 0o700 });
+	const events: Record<string, unknown>[] = [], composedPrompt = promptFromContext(context);
+	const providerArguments = ['exec', '--json', '--ephemeral', '--ignore-user-config', '--dangerously-bypass-approvals-and-sandbox', ...(writableProject ? [] : ['--skip-git-repo-check']), '--model', assignment.modelPolicy.model,
+		'--enable', 'code_mode_host', '--disable', 'browser_use', '--disable', 'apps', '--disable', 'multi_agent_v2', '--disable', 'image_generation', '--color', 'never', '--output-last-message', responsePath, '-C', '/workspace/project', '-'];
+	try {
+		await run('/usr/local/bin/codex', providerArguments, {
+			cwd: '/workspace/project', input: composedPrompt, env: { PATH: '/usr/local/bin:/usr/bin:/bin', HOME: codexHome, CODEX_HOME: codexHome, OPENAI_BASE_URL: relay.baseUrl, OPENAI_API_KEY: 'treeseed-assignment-relay', LANG: 'C.UTF-8' },
+			onLine(line) { try { events.push(record(JSON.parse(line))); } catch { events.push({ type: 'provider.event.invalid', digest: createHash('sha256').update(line).digest('hex') }); } },
+		});
+		const responseMarkdown = (await readFile(responsePath, 'utf8')).trim(); if (!responseMarkdown) throw new Error('Execution provider returned an empty response.');
+		const artifacts: Array<{ id: string; path: string; digest: string; mediaType: string; bytes: number }> = [];
+		if (writableProject) {
+			const patch = (await run('/usr/bin/git', ['diff', '--binary', '--full-index', 'HEAD'], { cwd: '/workspace/project', captureStdout: true, maxStdoutBytes: assignment.outputs.find((output) => output.id === 'project-patch')?.maxBytes })).stdout;
+			if (patch) {
+				const patchPath = resolve(outputRoot, 'project.patch'); await writeFile(patchPath, patch, { mode: 0o600 });
+				artifacts.push({ id: 'project-patch', path: '/run/treeseed-output/project.patch', digest: await fileDigest(patchPath), mediaType: 'application/vnd.treeseed.git-patch', bytes: Buffer.byteLength(patch) });
+			}
+		}
+		const completed = [...events].reverse().find((event) => text(event.type).includes('completed')) ?? {}, elapsedSeconds = Number(process.hrtime.bigint() - started) / 1e9, usageAfter = process.resourceUsage();
+		const result = sandboxResultSchema.parse({ schemaVersion: 'treeseed.sandbox-result/v1', sandboxId, assignmentId: assignment.assignmentId,
+			status: responseMarkdown === '<!-- treeseed:abstain -->' ? 'completed' : 'completed', summary: 'Kata assignment completed.', responseMarkdown,
+			artifacts, usage: { ...record(completed.usage), provenance: Object.keys(record(completed.usage)).length ? 'execution-provider' : 'unavailable', elapsedSeconds,
+				cpuUserMicros: usageAfter.userCPUTime - usageBefore.userCPUTime, cpuSystemMicros: usageAfter.systemCPUTime - usageBefore.systemCPUTime, peakRssBytes: usageAfter.maxRSS * 1024 },
+			diagnostics: { systemPrompt: composedPrompt, providerEvents: events, providerArguments, model: assignment.modelPolicy.model, provider: assignment.modelPolicy.provider, contextManifest: context,
+				guestKernel: (await readFile('/proc/version', 'utf8')).trim(), guestUid: process.getuid?.() ?? null, sandboxProfile: assignment.profile }, teardown: { verified: false, completedAt: null } });
+		await writeFile(resolve(outputRoot, 'result.json'), `${JSON.stringify(result)}\n`, { mode: 0o600 });
+	} finally { await relay.close(); }
+}
+
+if (process.argv[1]?.endsWith('/sandbox/guest.js')) runSandboxGuest().catch(async (error) => {
+	await mkdir(outputRoot, { recursive: true });
+	await writeFile(resolve(outputRoot, 'failure.json'), `${JSON.stringify({ error: error instanceof Error ? error.message : String(error) })}\n`).catch(() => undefined);
+	process.stderr.write(`${error instanceof Error ? error.stack ?? error.message : String(error)}\n`); process.exitCode = 1;
+});

--- a/tests/modern/codex-chat-executor.test.ts
+++ b/tests/modern/codex-chat-executor.test.ts
@@ -1,7 +1,12 @@
 import { describe, expect, it } from 'vitest';
-import { discussionMessageSourcePaths, readDiscussionSourceMessage } from '../../src/provider/execution/codex-chat-executor.ts';
+import { createHash } from 'node:crypto';
+import { assertObjectiveContentModel, discussionMessageSourcePaths, readDiscussionSourceMessage, readIdentityContext, readableCloneUrl, validatedSnapshotPaths } from '../../src/provider/execution/codex-chat-executor.ts';
 
 describe('Codex chat executor', () => {
+	it('uses a non-interactive readable URL for public GitHub project workspaces', () => {
+		expect(readableCloneUrl('git@github.com:treeseed-ai/sdk.git')).toBe('https://github.com/treeseed-ai/sdk.git');
+		expect(readableCloneUrl('https://example.test/project.git')).toBe('https://example.test/project.git');
+	});
 	it('accepts root and nested TreeDX discussion-message references', () => {
 		expect(discussionMessageSourcePaths({ sourceMessageRefs: [
 			'discussion-messages/topic/message.mdx',
@@ -13,6 +18,35 @@ describe('Codex chat executor', () => {
 			'discussion-messages/topic/second.mdx',
 			'src/content/discussion-messages/topic/legacy.mdx',
 		]);
+	});
+	it('rejects unsafe, duplicate, and parent-colliding TreeDX snapshot paths', () => {
+		expect(validatedSnapshotPaths([{ path: 'objectives/core.mdx' }, { path: 'agents/architect.mdx' }])).toEqual(['objectives/core.mdx', 'agents/architect.mdx']);
+		for (const entries of [[{ path: '../secret' }], [{ path: 'a\\b' }], [{ path: 'a' }, { path: 'a' }], [{ path: 'a' }, { path: 'a/b' }]]) expect(() => validatedSnapshotPaths(entries)).toThrow();
+	});
+
+	it('requires objective-directory Markdown to satisfy the SDK objective content model', () => {
+		expect(() => assertObjectiveContentModel('objectives/core.mdx', { frontmatter: { title: 'Core objective' } })).not.toThrow();
+		expect(() => assertObjectiveContentModel('objectives/core.md', { frontmatter: {} })).toThrow(/SDK objective content model/u);
+		expect(() => assertObjectiveContentModel('knowledge/core.md', { frontmatter: {} })).not.toThrow();
+	});
+
+	it('resolves the logical core objective to the exact file present in the frozen snapshot', async () => {
+		let requested: string[] = [];
+		const context = await readIdentityContext({ assignment: { metadata: { identityManifest: {
+			agentHandle: '@sdk/architect', repositoryId: 'repo-1', immutableRef: 'commit-1',
+			agentProfile: { path: 'agents/architect.yaml', expectedRevision: 'commit-1' },
+			coreObjective: { path: 'objectives/core', candidates: ['objectives/core.mdx', 'objectives/core.md'], expectedRevision: 'commit-1' },
+			projectReadme: { path: 'README.md', expectedRevision: 'commit-1' }, instructionTemplates: [],
+		} } }, assignmentId: 'assignment-1', leaseToken: 'lease', runnerId: 'runner', treeDx: {
+			projectId: 'project-1', repositoryId: 'repo-1', workspaceId: 'workspace-1', baseRef: 'commit-1', invoke: async (_operationId, value: any) => {
+				requested = value.body.paths; return { data: { result: { files: [
+					{ path: 'agents/architect.yaml', content: 'profile' }, { path: 'objectives/core.md', content: 'objective', frontmatter: { title: 'Core objective' } }, { path: 'README.md', content: 'readme' },
+				] } } };
+			},
+		} }, new Set(['agents/architect.yaml', 'objectives/core.md', 'README.md']));
+		expect(requested).toContain('objectives/core.md');
+		expect(requested).not.toContain('objectives/core.mdx');
+		expect((context.manifest.sources as any[])[1]).toMatchObject({ logicalPath: 'objectives/core', path: 'objectives/core.md' });
 	});
 
 	it('reads the committed discussion message at the assignment exact ref', async () => {
@@ -29,5 +63,34 @@ describe('Codex chat executor', () => {
 		expect(input).toEqual({ path: { repoId: 'repo-1' }, body: {
 			ref: 'commit-1', paths: ['discussion-messages/topic/message.mdx'], encoding: 'utf8', parseFrontmatter: true, allowProtected: true,
 		} });
+	});
+
+	it('verifies exact identity, objective, and instruction sources at the immutable TreeDX ref', async () => {
+		const profile = 'name: Architect'; const digest = `sha256:${createHash('sha256').update(profile).digest('hex')}`; let input: any;
+		const context = await readIdentityContext({ assignment: { metadata: { identityManifest: {
+			agentHandle: '@sdk/architect', repositoryId: 'repo-1', immutableRef: 'commit-1',
+			agentProfile: { path: 'agents/architect.yaml', expectedRevision: 'commit-1', digest },
+			coreObjective: { path: 'objectives/core', candidates: ['objectives/core.mdx', 'objectives/core.md'], expectedRevision: 'commit-1' },
+			projectReadme: { path: 'README.md', expectedRevision: 'commit-1' },
+			instructionTemplates: [{ path: 'instructions/chat.md', expectedRevision: 'commit-1' }],
+		} } }, assignmentId: 'assignment-1', leaseToken: 'lease', runnerId: 'runner',
+			treeDx: { projectId: 'project-1', repositoryId: 'repo-1', workspaceId: 'workspace-1', baseRef: 'commit-1', invoke: async (_operationId, value) => { input = value; return { data: { result: { files: [
+				{ path: 'agents/architect.yaml', content: profile }, { path: 'objectives/core.mdx', content: '# Objective', frontmatter: { title: 'Core objective' } }, { path: 'README.md', content: '# SDK' }, { path: 'instructions/chat.md', content: 'Be concise.' },
+			] } } }; } } });
+		expect(input.body.ref).toBe('commit-1');
+		expect(context.manifest.agentHandle).toBe('@sdk/architect');
+		expect((context.manifest.sources as any[]).map((source) => source.path)).toEqual(['agents/architect.yaml', 'objectives/core.mdx', 'README.md', 'instructions/chat.md']);
+		expect((context.manifest.sources as any[])[1].logicalPath).toBe('objectives/core');
+		expect((context.manifest.sources as any[]).every((source) => source.disposition === 'prompt-injected')).toBe(true);
+	});
+
+	it('fails closed when identity authority or content digest is mismatched', async () => {
+		const request: any = { assignment: { metadata: { identityManifest: { agentHandle: '@sdk/architect', repositoryId: 'repo-1', immutableRef: 'commit-1',
+			agentProfile: { path: 'agents/architect.yaml', expectedRevision: 'commit-1', digest: 'sha256:wrong' }, coreObjective: { paths: ['objectives/core.mdx'], expectedRevision: 'commit-1' }, instructionTemplates: [] } } },
+			assignmentId: 'assignment-1', leaseToken: 'lease', runnerId: 'runner', treeDx: { projectId: 'project-1', repositoryId: 'repo-1', workspaceId: 'workspace-1', baseRef: 'commit-1',
+				invoke: async () => ({ data: { result: { files: [{ path: 'agents/architect.yaml', content: 'profile' }, { path: 'objectives/core.mdx', content: 'objective', frontmatter: { title: 'Core objective' } }] } } }) } };
+		await expect(readIdentityContext(request)).rejects.toThrow(/digest mismatch/u);
+		request.treeDx.baseRef = 'commit-2';
+		await expect(readIdentityContext(request)).rejects.toThrow(/does not match/u);
 	});
 });

--- a/tests/modern/provider-boundary.test.ts
+++ b/tests/modern/provider-boundary.test.ts
@@ -47,9 +47,9 @@ describe('Agent package ownership boundary', () => {
 			const second = await ensureCapacityProviderIdentity(input);
 			expect(second.publicJwk).toEqual(first.publicJwk);
 			expect(statSync(resolve(dataDirectory, 'identity-v3.json')).mode & 0o777).toBe(0o600);
-			const stored = JSON.parse(readFileSync(resolve(dataDirectory, 'identity-v3.json'), 'utf8')) as { d?: string; x?: string };
-			expect(stored.x).toBe(first.publicJwk.x);
-			expect(typeof stored.d).toBe('string');
+			const stored = readFileSync(resolve(dataDirectory, 'identity-v3.json'), 'utf8');
+			expect(stored).toContain('treeseed.encrypted-envelope/v1');
+			expect(stored).not.toContain(first.publicJwk.x);
 		} finally {
 			rmSync(dataDirectory, { recursive: true, force: true });
 		}

--- a/tests/modern/release-publication.test.ts
+++ b/tests/modern/release-publication.test.ts
@@ -19,7 +19,7 @@ describe('Agent RC publication', () => {
 	});
 
 	it('materializes an exact no-build production bundle', () => {
-		execFileSync(process.execPath, ['--import', 'tsx', 'scripts/release/create-component-release.ts'], { env: { ...process.env, TREESEED_RELEASE: '0.13.0-rc.10', TREESEED_SOURCE_COMMIT: 'a'.repeat(40), TREESEED_MANAGER_DIGEST: hash('b'), TREESEED_RUNNER_DIGEST: hash('c') } });
+		execFileSync(process.execPath, ['--import', 'tsx', 'scripts/release/create-component-release.ts'], { env: { ...process.env, TREESEED_RELEASE: '0.13.0-rc.10', TREESEED_SOURCE_COMMIT: 'a'.repeat(40), TREESEED_MANAGER_DIGEST: hash('b'), TREESEED_RUNNER_DIGEST: hash('c'), TREESEED_GUEST_DIGEST: hash('d') } });
 		const compose = readFileSync('release-assets/compose.yml', 'utf8');
 		const release = JSON.parse(readFileSync('release-assets/component-release.json', 'utf8')) as { release: string; revision: number; runtime: { compose: { files: Array<{ path: string; digest: string }> }; dependencies: Array<{ id: string; locality: string }> }; track: string; source: { commit: string }; stableBase: { catalogDigest: unknown }; images: Array<{ digest: string }> };
 		expect(compose).not.toMatch(/\bbuild\s*:/u);
@@ -27,7 +27,7 @@ describe('Agent RC publication', () => {
 		expect(release.track).toBe('development');
 		expect(release.source.commit).toBe('a'.repeat(40));
 		expect(release.stableBase.catalogDigest).toBeNull();
-		expect(release.images.map((image) => image.digest)).toEqual([hash('b'), hash('c')]);
+		expect(release.images.map((image) => image.digest)).toEqual([hash('b'), hash('c'), hash('d')]);
 		expect(release.release).toBe('0.13.0~rc10-1');
 		expect(release.revision).toBe(1);
 		expect(release.runtime.compose.files).toEqual([{ path: 'compose.yml', digest: expect.stringMatching(/^sha256:[a-f0-9]{64}$/u) }]);
@@ -43,7 +43,7 @@ describe('Agent RC publication', () => {
 		expect(readFileSync('Dockerfile', 'utf8')).toContain('FROM node:24-alpine');
 	});
 
-	it('ships an exact Codex runtime with manager-controlled credential custody', () => {
+	it('ships Codex only in the brokered sandbox guest and gives providers only the broker socket', () => {
 		const packageJson = JSON.parse(readFileSync('package.json', 'utf8')) as { dependencies: Record<string, string> };
 		const dockerfile = readFileSync('Dockerfile', 'utf8');
 		const entrypoint = readFileSync('docker-entrypoint.sh', 'utf8');
@@ -51,15 +51,15 @@ describe('Agent RC publication', () => {
 		const workflow = readFileSync('.github/workflows/publish.yml', 'utf8');
 		expect(packageJson.dependencies['@openai/codex']).toBe('0.149.0');
 		expect(dockerfile).toContain('/app/node_modules/@openai/codex/bin/codex.js');
-		expect(entrypoint).toContain('Codex authentication source must be a regular, non-symlink file.');
-		expect(entrypoint).toContain('Capacity-provider manifest source must be a regular, non-symlink file.');
-		expect(entrypoint).toContain('export TREESEED_CAPACITY_PROVIDER_MANIFEST="$MANIFEST_FILE"');
-		expect(entrypoint).toContain('[ "${1:-}" = "healthcheck" ]');
-		expect(compose).toContain('/etc/treeseed/credentials/agent-codex-auth');
-		expect(compose).toContain('TREESEED_CAPACITY_PROVIDER_SOURCE: /config/treeseed.capacity-provider.yaml');
-		expect(compose).toContain('TREESEED_CAPACITY_PROVIDER_MANIFEST: /data/config/treeseed.capacity-provider.yaml');
+		expect(entrypoint).toContain('provider manager and runner containers must run unprivileged');
+		expect(entrypoint).toContain('rewrap-vault.js');
+		expect(entrypoint).not.toContain('CODEX_AUTH');
+		expect(compose).not.toContain('/etc/treeseed/credentials/agent-codex-auth');
+		expect(compose).toContain('/run/treeseed/sandbox/broker.sock');
+		expect(compose).toContain('TREESEED_CAPACITY_PROVIDER_MANIFEST: /config/treeseed.capacity-provider.yaml');
 		expect(compose).toContain('TREESEED_PROVIDER_ENVIRONMENT: ${TREESEED_PROVIDER_ENVIRONMENT:-managed}');
-		expect(compose).toContain('TREESEED_CODEX_AUTH_FILE: /data/credentials/codex-auth.json');
+		expect(compose).toContain('TREESEED_REQUIRE_MICROVM: "true"');
+		expect(compose).not.toContain('TREESEED_CODEX_AUTH_FILE');
 		expect(workflow).toContain('codex-cli 0.149.0');
 	});
 });

--- a/treeseed.package.yaml
+++ b/treeseed.package.yaml
@@ -37,6 +37,13 @@ artifacts:
     architectures:
       - amd64
       - arm64
+  - provider: docker
+    name: treeseed/agent-sandbox-guest
+    dockerfile: Dockerfile
+    target: sandbox-guest
+    role: sandbox-guest
+    architectures:
+      - amd64
 releaseGate:
   workflow: verify.yml
 development:
@@ -91,6 +98,9 @@ capacityProvider:
     runner:
       image: treeseed/agent-runner
       target: agent-runner
+    sandboxGuest:
+      image: treeseed/agent-sandbox-guest
+      target: sandbox-guest
   local:
     composeFile: compose.capacity-provider.yml
     projectName: treeseed-capacity-provider


### PR DESCRIPTION
Implements the v4 microVM capacity provider runtime, exact assignment inputs, guest execution, broker/model relay integration, encrypted provider credential vault, lease renewal, and manager/runner/guest image release custody.\n\nVerification: npm run release:verify (34 tests and packed install).