### PR TITLE
Separate provider and guest runtime closures

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,7 +20,8 @@ COPY --chown=65532:65532 .treeseed/docker/runtime/shared/package.json ./package.
 COPY --chown=65532:65532 .treeseed/docker/runtime/shared/node_modules ./node_modules
 COPY --chown=65532:65532 docker-entrypoint.sh ./docker-entrypoint.sh
 
-RUN chmod 0755 /app/docker-entrypoint.sh \
+RUN rm -rf /app/node_modules/@openai \
+	&& chmod 0755 /app/docker-entrypoint.sh \
 	&& chown -R 65532:65532 /data
 
 EXPOSE 3100

--- a/scripts/capacity/providers/build-capacity-provider-container.ts
+++ b/scripts/capacity/providers/build-capacity-provider-container.ts
@@ -290,7 +290,6 @@ function pruneProviderRuntimeToolingFromRuntimeTree(runtimeRoot: string) {
 	const commonTooling = [
 		'@cloudflare',
 		'@img',
-		'@openai',
 		'miniflare',
 		'playwright',
 		'playwright-core',

--- a/tests/modern/release-publication.test.ts
+++ b/tests/modern/release-publication.test.ts
@@ -44,6 +44,7 @@ describe('Agent RC publication', () => {
 		expect(readFileSync('Dockerfile', 'utf8')).toContain('FROM ${UBUNTU_BASE} AS agent-provider-base');
 		expect(readFileSync('Dockerfile', 'utf8')).toContain('.treeseed/docker/runtime/shared/package.json ./package.json');
 		expect(readFileSync('Dockerfile', 'utf8')).toContain('.treeseed/docker/runtime/shared/node_modules ./node_modules');
+		expect(readFileSync('Dockerfile', 'utf8')).toContain('rm -rf /app/node_modules/@openai');
 		expect(readFileSync('.github/workflows/publish.yml', 'utf8')).toContain('Verify candidate provider runtime starts');
 		expect(readFileSync('Dockerfile', 'utf8')).toContain('FROM ${UBUNTU_BASE} AS sandbox-base');
 		expect(readFileSync('Dockerfile.sandbox-codex', 'utf8')).toContain('FROM ${SANDBOX_BASE}');


### PR DESCRIPTION
## Outcome
Preserve Codex runtime packages for sandbox guests while removing them from provider manager and runner images.

## Work authority
- Work item / Issue: Agent rc28 reconciliation and provider-owned sandbox release hardening
- Proposal / decision: Capability-Driven Capacity Marketplace and Provider-Owned Sandboxes
- Assignment / checkpoint: Provider/guest runtime closure release gate
- Actor: Codex
- Human authority: Adrian requested repair and completion verification
- Agent / capacity provider: TreeSeed development capacity provider
- Exact base ref: aef20cba951d143240ba225e489e93b309d8ffb2
- Exact head ref: f83eb420930ef0fbd0e63528add648b62658bb68

## Plan
Keep the shared prepared runtime complete for guest image construction, then prune provider-only unnecessary Codex packages in the provider image layer.

## Changes and commits
- f83eb420930ef0fbd0e63528add648b62658bb68 Separate provider and guest runtime closures

## Verification
- npm run verify:direct
- npm run capacity-provider:build -- --prepare-only
- Built and started treeseed/agent-manager:rc28-split-proof
- Verified provider image excludes /app/node_modules/@openai
- Built treeseed/sandbox-base and treeseed/sandbox-codex locally
- Verified sandbox Codex reports codex-cli 0.149.0

## Risk and rollback
Risk is limited to image runtime contents. Roll back this commit to restore the prior shared pruning behavior; rc28 has not yet been tagged or promoted.

## Completion summary
Provider images retain only their runtime closure while sandbox-codex retains the Codex CLI required for assignment execution.

## Submission checklist
- [x] Agent-assisted under human authority
- [x] The change is bounded to the stated work item and target repository.
- [x] Exact base and head refs are recorded and the branch is ready for review.
- [x] Verification and compatibility evidence are recorded above.
- [x] No plaintext secrets, credentials, machine state, or unrelated residue are included.
- [x] Plan, status, commits, and completion summary form a complete durable record.
- [x] Rollback or recovery steps are documented and executable.