### PR TITLE
Make Agent health require a readable manifest

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@treeseed/agent",
-  "version": "0.13.0-rc.28",
+  "version": "0.13.0-rc.29",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@treeseed/agent",
-      "version": "0.13.0-rc.28",
+      "version": "0.13.0-rc.29",
       "license": "Apache-2.0",
       "dependencies": {
         "@openai/codex": "0.149.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@treeseed/agent",
-  "version": "0.13.0-rc.28",
+  "version": "0.13.0-rc.29",
   "description": "Treeseed agent service runtime package.",
   "license": "Apache-2.0",
   "repository": {

--- a/src/provider/lifecycle/entrypoint.ts
+++ b/src/provider/lifecycle/entrypoint.ts
@@ -136,7 +136,9 @@ async function main() {
 	}
 	if (role === 'healthcheck' || role === 'doctor') {
 		const { checkProviderHealth } = await import('./lifecycle.ts');
-		emit(await checkProviderHealth(config));
+		const health = await checkProviderHealth(config);
+		emit(health);
+		if (role === 'healthcheck' && health.status !== 'ok') process.exitCode = 1;
 		return;
 	}
 	if (role === 'plan') {

--- a/src/provider/lifecycle/lifecycle.ts
+++ b/src/provider/lifecycle/lifecycle.ts
@@ -9,20 +9,22 @@ import { createProviderControlPlaneClient } from '../coordination/client.ts';
 import { ProviderLocalCapacityStore } from '../capacity/capacity-core/local-capacity-store.ts';
 import { observeProviderDiskCapacity } from '../runtime/disk-capacity.ts';
 
-export function okPayload(role: string, payload: Record<string, unknown> = {}) {
-	return { ok: true, role, ...payload };
+export function okPayload<T extends Record<string, unknown>>(role: string, payload: T) {
+	return { ok: true as const, role, ...payload };
 }
 
 export async function checkProviderHealth(config: ProviderHostRuntimeConfig) {
 	await mkdir(config.dataDir, { recursive: true });
 	const writable = await access(config.dataDir, constants.W_OK).then(() => true, () => false);
 	const disk = writable ? await observeProviderDiskCapacity({ path: config.dataDir, env: config.env }) : null;
+	const manifest = config.manifestPath ? (await loadProviderManifest(config.manifestPath, config.dataDir)).manifest : null;
 	return okPayload('healthcheck', {
 		status: writable && disk?.ok ? 'ok' : 'degraded',
 		environment: config.environment,
 		dataDirWritable: writable,
 		disk,
 		manifestConfigured: Boolean(config.manifestPath),
+		manifestVersion: manifest?.schemaVersion ?? null,
 		executorConfigured: Boolean(config.executorModule),
 	});
 }

--- a/tests/modern/release-publication.test.ts
+++ b/tests/modern/release-publication.test.ts
@@ -45,6 +45,8 @@ describe('Agent RC publication', () => {
 		expect(readFileSync('Dockerfile', 'utf8')).toContain('.treeseed/docker/runtime/shared/package.json ./package.json');
 		expect(readFileSync('Dockerfile', 'utf8')).toContain('.treeseed/docker/runtime/shared/node_modules ./node_modules');
 		expect(readFileSync('Dockerfile', 'utf8')).toContain('rm -rf /app/node_modules/@openai');
+		expect(readFileSync('src/provider/lifecycle/lifecycle.ts', 'utf8')).toContain('loadProviderManifest(config.manifestPath, config.dataDir)');
+		expect(readFileSync('src/provider/lifecycle/entrypoint.ts', 'utf8')).toContain("health.status !== 'ok'");
 		expect(readFileSync('.github/workflows/publish.yml', 'utf8')).toContain('Verify candidate provider runtime starts');
 		expect(readFileSync('Dockerfile', 'utf8')).toContain('FROM ${UBUNTU_BASE} AS sandbox-base');
 		expect(readFileSync('Dockerfile.sandbox-codex', 'utf8')).toContain('FROM ${SANDBOX_BASE}');


### PR DESCRIPTION
## Outcome
Prevent Agent containers from reporting healthy when their provider manifest is unreadable or invalid.

## Work authority
- Work item / Issue: Failing reconciliation cycles and false-positive Agent health
- Proposal / decision: Kata assignment sandboxing and provider-owned sandbox rollout
- Assignment / checkpoint: Agent rc29 health gate
- Actor: Codex
- Human authority: Adrian requested reconciliation repair before further work
- Agent / capacity provider: TreeSeed development capacity provider
- Exact base ref: dc754d85e47f8766869a90acc0c3f24e60cf7f50
- Exact head ref: 70292bd198ddb6c8c1443c92a5273f0958ff8460

## Plan
Load and validate the configured manifest during health checks and return a failing process status for degraded health.

## Changes and commits
- 70292bd198ddb6c8c1443c92a5273f0958ff8460 Make Agent health require a readable manifest

## Verification
- npm run verify:direct
- 8 test files and 34 tests passed
- Packed-install verification passed

## Risk and rollback
The stricter health gate may expose existing invalid configurations, which is intended. Revert this commit to restore the prior shallow health check.

## Completion summary
Agent health now represents usable provider configuration rather than only writable disk state.

## Submission checklist
- [x] Agent-assisted under human authority
- [x] The change is bounded to the stated work item and target repository.
- [x] Exact base and head refs are recorded and the branch is ready for review.
- [x] Verification and compatibility evidence are recorded above.
- [x] No plaintext secrets, credentials, machine state, or unrelated residue are included.
- [x] Plan, status, commits, and completion summary form a complete durable record.
- [x] Rollback or recovery steps are documented and executable.