### PR TITLE
Fix broker socket restart visibility

### DIFF
--- a/compose.capacity-provider.yml
+++ b/compose.capacity-provider.yml
@@ -25,7 +25,7 @@ services:
     volumes: &provider-volumes
       - "${TREESEED_PROVIDER_HOST_DATA_DIR:-.treeseed/local-capacity-providers/agent-standalone}:/data"
       - "${TREESEED_CAPACITY_PROVIDER_MANIFEST:-./treeseed.capacity-provider.yaml}:/config/treeseed.capacity-provider.yaml:ro"
-      - "/run/treeseed/sandbox/broker.sock:/run/treeseed/sandbox/broker.sock"
+      - "/run/treeseed/sandbox:/run/treeseed/sandbox:ro"
       - "/etc/treeseed/sandbox/relay-ca.crt:/etc/treeseed/sandbox/relay-ca.crt:ro"
       - "/run/treeseed/component-credentials/agent:/run/credentials:ro"
     group_add: &broker-groups

--- a/deploy/compose.template.yml
+++ b/deploy/compose.template.yml
@@ -23,8 +23,9 @@ services:
         target: /config/treeseed.capacity-provider.yaml
         read_only: true
       - type: bind
-        source: /run/treeseed/sandbox/broker.sock
-        target: /run/treeseed/sandbox/broker.sock
+        source: /run/treeseed/sandbox
+        target: /run/treeseed/sandbox
+        read_only: true
       - type: bind
         source: /etc/treeseed/sandbox/relay-ca.crt
         target: /etc/treeseed/sandbox/relay-ca.crt

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@treeseed/agent",
-  "version": "0.13.0-rc.29",
+  "version": "0.13.0-rc.30",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@treeseed/agent",
-      "version": "0.13.0-rc.29",
+      "version": "0.13.0-rc.30",
       "license": "Apache-2.0",
       "dependencies": {
         "@openai/codex": "0.149.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@treeseed/agent",
-  "version": "0.13.0-rc.29",
+  "version": "0.13.0-rc.30",
   "description": "Treeseed agent service runtime package.",
   "license": "Apache-2.0",
   "repository": {

--- a/tests/modern/release-publication.test.ts
+++ b/tests/modern/release-publication.test.ts
@@ -66,7 +66,9 @@ describe('Agent RC publication', () => {
 		expect(entrypoint).toContain('rewrap-vault.js');
 		expect(entrypoint).not.toContain('CODEX_AUTH');
 		expect(compose).not.toContain('/etc/treeseed/credentials/agent-codex-auth');
-		expect(compose).toContain('/run/treeseed/sandbox/broker.sock');
+		expect(compose).toContain('source: /run/treeseed/sandbox');
+		expect(compose).toContain('target: /run/treeseed/sandbox');
+		expect(compose).not.toContain('source: /run/treeseed/sandbox/broker.sock');
 		expect(compose).toContain('TREESEED_CAPACITY_PROVIDER_MANIFEST: /config/treeseed.capacity-provider.yaml');
 		expect(compose).toContain('TREESEED_PROVIDER_ENVIRONMENT: ${TREESEED_PROVIDER_ENVIRONMENT:-managed}');
 		expect(compose).toContain('TREESEED_REQUIRE_MICROVM: "true"');


### PR DESCRIPTION
## Outcome

Provider containers retain broker connectivity across broker restarts by mounting the runtime directory instead of a replaceable socket inode.

## Work authority

- Work item / Issue: Operator-requested reconciliation reliability fix
- Proposal / decision: Capability-driven provider sandbox rollout validation
- Assignment / checkpoint: SDK architect end-to-end validation checkpoint
- Actor: Codex primary agent
- Human authority: adrianwebb
- Agent / capacity provider: Codex under adrianwebb authority
- Exact base ref: staging 9edffc8dc1dac2c2b3f8bdec7d70b9d6677b6d8e
- Exact head ref: codex/broker-directory-mount-rc30 f79745f38846a6f5957bda3b314760e4b16fa98e

Contributor mode (select one):

- [ ] Human-authored
- [x] Agent-assisted under human authority
- [ ] Agent-authored under human authority

## Plan

Reproduce the failed provider availability, identify the stale Unix socket bind, mount the stable parent runtime directory read-only, add regression assertions, and release rc30. Complete.

## Changes and commits

- f79745f38846a6f5957bda3b314760e4b16fa98e mounts /run/treeseed/sandbox read-only in managed and standalone provider Compose definitions and adds regression coverage.

## Verification

- npm run verify:direct
- 8 test files and 34 tests passed; packed-install verification passed.
- Focused release-publication test passed.

## Risk and rollback

The provider still receives only the broker runtime directory and broker group, not containerd or Docker sockets. Roll back by reverting f79745f if directory mounting causes an unexpected runtime compatibility issue.

## Completion summary

Source fix and tests are complete. Release promotion and manager reconciliation follow after merge.

## Submission checklist

- [x] The change is bounded to the stated work item and target repository.
- [x] Exact base and head refs are recorded and the branch is ready for review.
- [x] Verification and compatibility evidence are recorded above.
- [x] No plaintext secrets, credentials, machine state, or unrelated residue are included.
- [x] Plan, status, commits, and completion summary form a complete durable record.
- [x] Rollback or recovery steps are documented and executable.