### PR TITLE
Fail provider health when broker is unavailable

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@treeseed/agent",
-  "version": "0.13.0-rc.30",
+  "version": "0.13.0-rc.31",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@treeseed/agent",
-      "version": "0.13.0-rc.30",
+      "version": "0.13.0-rc.31",
       "license": "Apache-2.0",
       "dependencies": {
         "@openai/codex": "0.149.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@treeseed/agent",
-  "version": "0.13.0-rc.30",
+  "version": "0.13.0-rc.31",
   "description": "Treeseed agent service runtime package.",
   "license": "Apache-2.0",
   "repository": {

--- a/src/provider/execution/sandbox-broker-client.ts
+++ b/src/provider/execution/sandbox-broker-client.ts
@@ -22,7 +22,7 @@ function call<T>(socketPath: string, method: string, path: string, body?: unknow
 export class SandboxBrokerClient {
 	constructor(readonly socketPath: string) {}
 	private path(suffix: string) { return `/v${1}${suffix}`; }
-	status() { return call<Record<string, unknown>>(this.socketPath, 'GET', this.path('/status')); }
+	status(signal?: AbortSignal) { return call<Record<string, unknown>>(this.socketPath, 'GET', this.path('/status'), undefined, signal); }
 	prepare(assignment: SandboxAssignment, signal?: AbortSignal) { return call<{ sandboxId: string; operationToken: string }>(this.socketPath, 'POST', this.path('/sandboxes'), { assignment }, signal); }
 	upload(sandboxId: string, token: string, inputId: string, sourcePath: string, bytes: number, signal?: AbortSignal) {
 		return new Promise<void>((resolve, reject) => {

--- a/src/provider/lifecycle/lifecycle.ts
+++ b/src/provider/lifecycle/lifecycle.ts
@@ -8,6 +8,7 @@ import { loadProviderManifest } from '../configuration/manifest.ts';
 import { createProviderControlPlaneClient } from '../coordination/client.ts';
 import { ProviderLocalCapacityStore } from '../capacity/capacity-core/local-capacity-store.ts';
 import { observeProviderDiskCapacity } from '../runtime/disk-capacity.ts';
+import { SandboxBrokerClient } from '../execution/sandbox-broker-client.ts';
 
 export function okPayload<T extends Record<string, unknown>>(role: string, payload: T) {
 	return { ok: true as const, role, ...payload };
@@ -18,14 +19,21 @@ export async function checkProviderHealth(config: ProviderHostRuntimeConfig) {
 	const writable = await access(config.dataDir, constants.W_OK).then(() => true, () => false);
 	const disk = writable ? await observeProviderDiskCapacity({ path: config.dataDir, env: config.env }) : null;
 	const manifest = config.manifestPath ? (await loadProviderManifest(config.manifestPath, config.dataDir)).manifest : null;
+	const brokerSocket = manifest && manifest.schemaVersion !== 3 && manifest.sandbox.required ? manifest.sandbox.brokerSocket : null;
+	const broker = brokerSocket
+		? await new SandboxBrokerClient(brokerSocket).status(AbortSignal.timeout(3_000))
+			.then(() => ({ required: true, ready: true, socket: brokerSocket, reason: null }))
+			.catch((error: unknown) => ({ required: true, ready: false, socket: brokerSocket, reason: error instanceof Error ? error.message : String(error) }))
+		: { required: false, ready: true, socket: null, reason: null };
 	return okPayload('healthcheck', {
-		status: writable && disk?.ok ? 'ok' : 'degraded',
+		status: writable && disk?.ok && broker.ready ? 'ok' : 'degraded',
 		environment: config.environment,
 		dataDirWritable: writable,
 		disk,
 		manifestConfigured: Boolean(config.manifestPath),
 		manifestVersion: manifest?.schemaVersion ?? null,
 		executorConfigured: Boolean(config.executorModule),
+		broker,
 	});
 }
 


### PR DESCRIPTION
## Outcome

Managed microVM providers report degraded health when the assignment broker cannot be reached, preventing Docker and reconciliation from accepting a provider that can only publish unavailable capacity.

## Work authority

- Work item / Issue: Live Agent rc30 health accepted an invisible broker socket
- Proposal / decision: Fail-closed Kata provider availability
- Assignment / checkpoint: SDK architect end-to-end validation checkpoint
- Actor: Codex primary agent
- Human authority: adrianwebb
- Agent / capacity provider: Codex under adrianwebb authority
- Exact base ref: staging 57eafb3cb739577afa1a21d089d3e6099309c9e4
- Exact head ref: codex/broker-healthcheck-rc31 57960ad9c2d894be995da397929f193c58d90f0b

Contributor mode (select one):

- [ ] Human-authored
- [x] Agent-assisted under human authority
- [ ] Agent-authored under human authority

## Plan

Probe the broker status endpoint for v4/v5 microVM manifests, expose its readiness and reason in health output, degrade on failure, and release rc31. Complete.

## Changes and commits

- 57960ad9c2d894be995da397929f193c58d90f0b adds abortable broker status checks to provider health and versions rc31.

## Verification

- npm run verify:direct
- File policy, declaration build, 8 test files/34 tests, and packed-install verification passed.
- Live evidence showed status=ok while the active availability snapshot reported broker ENOENT; this change closes that contradiction.

## Risk and rollback

The probe is bounded to three seconds and only required for v4/v5 manifests that declare sandbox.required. Revert 57960ad if a compatible broker implementation cannot serve the standardized status endpoint.

## Completion summary

Provider health now includes real broker reachability and fails closed; rc31 is ready for promotion.

## Submission checklist

- [x] The change is bounded to the stated work item and target repository.
- [x] Exact base and head refs are recorded and the branch is ready for review.
- [x] Verification and compatibility evidence are recorded above.
- [x] No plaintext secrets, credentials, machine state, or unrelated residue are included.
- [x] Plan, status, commits, and completion summary form a complete durable record.
- [x] Rollback or recovery steps are documented and executable.