### PR TITLE
Fix Codex sandbox guest arguments

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@treeseed/agent",
-  "version": "0.13.0-rc.33",
+  "version": "0.13.0-rc.34",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@treeseed/agent",
-      "version": "0.13.0-rc.33",
+      "version": "0.13.0-rc.34",
       "license": "Apache-2.0",
       "dependencies": {
         "@openai/codex": "0.149.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@treeseed/agent",
-  "version": "0.13.0-rc.33",
+  "version": "0.13.0-rc.34",
   "description": "Treeseed agent service runtime package.",
   "license": "Apache-2.0",
   "repository": {

--- a/src/sandbox/guest.ts
+++ b/src/sandbox/guest.ts
@@ -91,7 +91,7 @@ export async function runSandboxGuest() {
 	if (subscriptionAuth) await writeFile(resolve(codexHome, 'auth.json'), subscriptionAuth, { mode: 0o600 });
 	const relay = subscriptionAuth ? null : await startModelRelay(assignment, sandboxId, operationToken);
 	const events: Record<string, unknown>[] = [], composedPrompt = promptFromContext(context);
-	const providerArguments = ['exec', '--json', '--ephemeral', '--ignore-user-config', '--sandbox', 'workspace-write', '--approve-for-me', ...(writableProject ? [] : ['--skip-git-repo-check']), '--model', assignment.modelPolicy.model,
+	const providerArguments = ['exec', '--json', '--ephemeral', '--ignore-user-config', '--approve-for-me', ...(writableProject ? [] : ['--skip-git-repo-check']), '--model', assignment.modelPolicy.model,
 		'--enable', 'code_mode_host', '--disable', 'browser_use', '--disable', 'apps', '--disable', 'multi_agent_v2', '--disable', 'image_generation', '--color', 'never', '--output-last-message', responsePath, '-C', '/workspace/project', '-'];
 	try {
 		await run('/usr/local/bin/codex', providerArguments, {

--- a/tests/modern/release-publication.test.ts
+++ b/tests/modern/release-publication.test.ts
@@ -75,7 +75,8 @@ describe('Agent RC publication', () => {
 		expect(compose).not.toContain('TREESEED_CODEX_AUTH_FILE');
 		expect(workflow).toContain('codex-cli 0.149.0');
 		const guest = readFileSync('src/sandbox/guest.ts', 'utf8');
-		expect(guest).toContain("'--sandbox', 'workspace-write', '--approve-for-me'");
+		expect(guest).toContain("'--approve-for-me'");
+		expect(guest).not.toContain("'--sandbox', 'workspace-write'");
 		expect(guest).not.toContain("'--dangerously-bypass-approvals-and-sandbox'");
 		expect(guest).toContain("resolve(inputRoot, 'codex-auth.json')");
 	});


### PR DESCRIPTION
## Outcome

Codex Kata guests launch successfully with automatic workspace-scoped approval instead of passing mutually exclusive CLI flags.

## Work authority

- Work item / Issue: User-requested sub-one-minute chat execution validation in the active TreeSeed task
- Proposal / decision: Approved Kata assignment sandbox and provider-owned execution architecture
- Assignment / checkpoint: sdk-sandbox-validation-rc172
- Actor: Codex /root
- Human authority: adrian
- Agent / capacity provider: Codex /root using the local development capacity provider
- Exact base ref: staging 6ce55384acfa616378c9d43ca2b626f048a50ae6
- Exact head ref: codex/codex-sandbox-arguments-rc34 366d1c53311436a56540720799943271cbd82e7f

Contributor mode (select one):

- [ ] Human-authored
- [x] Agent-assisted under human authority
- [ ] Agent-authored under human authority

## Plan

Reproduce the guest failure, capture its protected failure record, remove the incompatible flag pair, verify the package, and promote the exact image through the normal release workflow. Status: implementation and local verification complete.

## Changes and commits

Commit 366d1c53311436a56540720799943271cbd82e7f removes the explicit --sandbox workspace-write pair while retaining --approve-for-me and adds a regression assertion.

## Verification

`npm run verify:direct` passed: file policies, build, 8 test files / 34 tests, package creation, and packed-install verification. The reproduced Codex 0.149 error explicitly reported that --sandbox cannot be used with --approve-for-me.

## Risk and rollback

Risk is limited to Codex guest invocation policy. Codex documents --approve-for-me as workspace-write automatic review, while Kata remains the outer assignment boundary. Roll back by reverting commit 366d1c53311436a56540720799943271cbd82e7f and restoring the prior image digest.

## Completion summary

The concrete guest startup incompatibility is fixed and verified locally. Release/image promotion and the real timed chat acceptance test remain next.

## Submission checklist

- [x] The change is bounded to the stated work item and target repository.
- [x] Exact base and head refs are recorded and the branch is ready for review.
- [x] Verification and compatibility evidence are recorded above.
- [x] No plaintext secrets, credentials, machine state, or unrelated residue are included.
- [x] Plan, status, commits, and completion summary form a complete durable record.
- [x] Rollback or recovery steps are documented and executable.