### PR TITLE
Make Kata the sole assignment sandbox

### DIFF
--- a/src/sandbox/guest.ts
+++ b/src/sandbox/guest.ts
@@ -91,7 +91,7 @@ export async function runSandboxGuest() {
 	if (subscriptionAuth) await writeFile(resolve(codexHome, 'auth.json'), subscriptionAuth, { mode: 0o600 });
 	const relay = subscriptionAuth ? null : await startModelRelay(assignment, sandboxId, operationToken);
 	const events: Record<string, unknown>[] = [], composedPrompt = promptFromContext(context);
-	const providerArguments = ['exec', '--json', '--ephemeral', '--ignore-user-config', '--approve-for-me', ...(writableProject ? [] : ['--skip-git-repo-check']), '--model', assignment.modelPolicy.model,
+	const providerArguments = ['exec', '--json', '--ephemeral', '--ignore-user-config', '--dangerously-bypass-approvals-and-sandbox', ...(writableProject ? [] : ['--skip-git-repo-check']), '--model', assignment.modelPolicy.model,
 		'--enable', 'code_mode_host', '--disable', 'browser_use', '--disable', 'apps', '--disable', 'multi_agent_v2', '--disable', 'image_generation', '--color', 'never', '--output-last-message', responsePath, '-C', '/workspace/project', '-'];
 	try {
 		await run('/usr/local/bin/codex', providerArguments, {

--- a/tests/modern/release-publication.test.ts
+++ b/tests/modern/release-publication.test.ts
@@ -75,9 +75,9 @@ describe('Agent RC publication', () => {
 		expect(compose).not.toContain('TREESEED_CODEX_AUTH_FILE');
 		expect(workflow).toContain('codex-cli 0.149.0');
 		const guest = readFileSync('src/sandbox/guest.ts', 'utf8');
-		expect(guest).toContain("'--approve-for-me'");
+		expect(guest).toContain("'--dangerously-bypass-approvals-and-sandbox'");
+		expect(guest).not.toContain("'--approve-for-me'");
 		expect(guest).not.toContain("'--sandbox', 'workspace-write'");
-		expect(guest).not.toContain("'--dangerously-bypass-approvals-and-sandbox'");
 		expect(guest).toContain("resolve(inputRoot, 'codex-auth.json')");
 	});
 });


### PR DESCRIPTION
## Outcome

Codex assignments execute without any human or internal approval workflow; the per-assignment Kata VM is the sole security boundary.

## Work authority

- Work item / Issue: User requirement that assignment execution providers contain no human approvals
- Proposal / decision: Kata per-assignment sandbox and provider-owned execution architecture
- Assignment / checkpoint: sdk-sandbox-validation-rc172
- Actor: Codex /root
- Human authority: adrian
- Agent / capacity provider: Codex /root using the local development capacity provider
- Exact base ref: staging d33ff1cfb44c54ee23302deb3a3c4ba7c0bd7794
- Exact head ref: codex/kata-is-the-sandbox-rc34 857bed6c1c0db29e966745a2e357617a47e9e137

Contributor mode (select one):

- [ ] Human-authored
- [x] Agent-assisted under human authority
- [ ] Agent-authored under human authority

## Plan

Remove Codex approval and inner sandbox negotiation, retain the Kata assignment boundary, verify package behavior, then rebuild and promote the Codex guest image.

## Changes and commits

Commit 857bed6c1c0db29e966745a2e357617a47e9e137 uses the Codex mode explicitly intended for externally sandboxed automation and asserts that no approval mode or competing workspace sandbox is passed.

## Verification

`npm run verify:direct` passed: file policies, build, 8 test files / 34 tests, package creation, and packed-install verification.

## Risk and rollback

Codex has unrestricted access inside its Kata guest, as required, but the guest receives only assignment-scoped mounts, network, credentials, resources, and outputs. Roll back by restoring the previous exact guest image digest.

## Completion summary

Human and Codex-internal approval paths are removed from assignment execution. Image promotion and the timed end-to-end chat test are next.

## Submission checklist

- [x] The change is bounded to the stated work item and target repository.
- [x] Exact base and head refs are recorded and the branch is ready for review.
- [x] Verification and compatibility evidence are recorded above.
- [x] No plaintext secrets, credentials, machine state, or unrelated residue are included.
- [x] Plan, status, commits, and completion summary form a complete durable record.
- [x] Rollback or recovery steps are documented and executable.
