### PR TITLE
Enforce canonical deployment boundaries

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -9,7 +9,7 @@ on:
         type: choice
         options:
           - staging
-          - prod
+          - production
       action_kind:
         required: true
         default: deploy_web
@@ -21,16 +21,13 @@ on:
       project_id:
         required: false
         type: string
-      preview_id:
-        required: false
-        type: string
 
 jobs:
   web:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-    environment: ${{ inputs.environment == 'prod' && 'production' || 'staging' }}
+    environment: ${{ inputs.environment }}
     defaults:
       run:
         working-directory: docs
@@ -48,7 +45,6 @@ jobs:
       TREESEED_WORKFLOW_ACTION: ${{ inputs.action_kind }}
       TREESEED_WORKFLOW_ENVIRONMENT: ${{ inputs.environment }}
       TREESEED_WORKFLOW_PROJECT: ${{ inputs.project_id || vars.TREESEED_PROJECT_ID || 'agent' }}
-      TREESEED_WORKFLOW_PREVIEW_ID: ${{ inputs.preview_id }}
     steps:
       - uses: actions/checkout@v4
 
@@ -72,5 +68,4 @@ jobs:
           set -euo pipefail
           EXTRA_ARGS=()
           if [[ -n "${TREESEED_WORKFLOW_PROJECT:-}" ]]; then EXTRA_ARGS+=(--project-id "${TREESEED_WORKFLOW_PROJECT}"); fi
-          if [[ -n "${TREESEED_WORKFLOW_PREVIEW_ID:-}" ]]; then EXTRA_ARGS+=(--preview-id "${TREESEED_WORKFLOW_PREVIEW_ID}"); fi
           node ./node_modules/@treeseed/sdk/scripts/tenant-workflow-action.js --action "${TREESEED_WORKFLOW_ACTION}" --environment "${TREESEED_WORKFLOW_ENVIRONMENT}" "${EXTRA_ARGS[@]}"

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -20,7 +20,7 @@ jobs:
   candidate-build:
     if: github.ref == 'refs/heads/staging'
     needs: [candidate-package, candidate-base-build]
-    environment: development
+    environment: staging
     runs-on: ${{ matrix.runner }}
     strategy:
       matrix:
@@ -59,7 +59,7 @@ jobs:
   candidate-base-build:
     if: github.ref == 'refs/heads/staging'
     needs: candidate-package
-    environment: development
+    environment: staging
     runs-on: ${{ matrix.runner }}
     strategy:
       matrix:
@@ -83,7 +83,7 @@ jobs:
   candidate-seal:
     if: github.ref == 'refs/heads/staging'
     needs: [candidate-build, candidate-base-build]
-    environment: development
+    environment: staging
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,6 +4,10 @@ The Agent package is an Apache-2.0 repository. It has no contributor-grant check
 
 Agents must act only within assignment and capacity-provider authority, preserve exact repository and commit evidence, and keep GitHub tokens, provider private keys, membership credentials, and runtime secrets outside agent execution workspaces. Repository publication remains in the trusted provider/API boundary.
 
+## Branch and deployment boundary
+
+`main` is the only production branch and maps only to the `production` deployment environment. `staging` is the only development-integration branch and maps only to the `staging` deployment environment. Short-lived pull-request branches may validate without deploying, but they must never define another deployment environment. Do not create or use `development`, `preview`, `stable`, or any other GitHub deployment environment; preview deployments are prohibited. Release tags may promote an exact reviewed `staging` commit to `production` without creating another branch or environment. Artifact channel names must never become GitHub deployment environments.
+
 ## Project library
 
 Use `trsd library show agent` and `status` before querying `treeseed-ai/agent-library`. Read root-level paths at an exact commit. Author only through governed library workspaces and reviews. Never recreate `src/content` or edit `.treeseed/data` directly.


### PR DESCRIPTION
Enforces the portfolio rule: main maps only to production; staging maps only to staging; short-lived PR branches do not create additional deployment environments; preview deployments are prohibited. Verification: 34 tests and packed install.