### PR TITLE
fix(provider): adopt reusable registration codes

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,16 +1,16 @@
 {
   "name": "@treeseed/agent",
-  "version": "0.13.0-rc.36",
+  "version": "0.13.0-rc.37",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@treeseed/agent",
-      "version": "0.13.0-rc.36",
+      "version": "0.13.0-rc.37",
       "license": "Apache-2.0",
       "dependencies": {
         "@openai/codex": "0.149.0",
-        "@treeseed/sdk": "0.13.0-rc.59",
+        "@treeseed/sdk": "0.13.0-rc.65",
         "esbuild": "0.28.2",
         "typescript": "^5.9.3",
         "yaml": "^2.8.1"
@@ -672,9 +672,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -692,9 +689,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -712,9 +706,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -732,9 +723,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -752,9 +740,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -772,9 +757,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -850,10 +832,9 @@
       "license": "MIT"
     },
     "node_modules/@treeseed/sdk": {
-      "version": "0.13.0-rc.59",
-      "resolved": "https://registry.npmjs.org/@treeseed/sdk/-/sdk-0.13.0-rc.59.tgz",
-      "integrity": "sha512-nEO0fm5Ii7Gb1e74DH0vWmt8lT6Ta8t/nIEFrZkK3Vvxx2yjc9EtlQR6C1q5m8vMGUbmfT1lBuexKx3lDKH7LA==",
-      "license": "Apache-2.0",
+      "version": "0.13.0-rc.65",
+      "resolved": "https://registry.npmjs.org/@treeseed/sdk/-/sdk-0.13.0-rc.65.tgz",
+      "integrity": "sha512-McRysmZzEXylsPKdIPxbO7Q3HnWKV0qnDrc54p87iUsIpiupe4YjPORTNyjcKG4YEyM1eQ6P72XkESnxgBxR+w==",
       "dependencies": {
         "@treeseed/treedx": "0.3.0-rc.4",
         "esbuild": "^0.28.0",
@@ -1279,9 +1260,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -1303,9 +1281,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -1327,9 +1302,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -1351,9 +1323,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@treeseed/agent",
-  "version": "0.13.0-rc.36",
+  "version": "0.13.0-rc.37",
   "description": "Treeseed agent service runtime package.",
   "license": "Apache-2.0",
   "repository": {
@@ -64,7 +64,7 @@
   },
   "dependencies": {
     "@openai/codex": "0.149.0",
-    "@treeseed/sdk": "0.13.0-rc.59",
+    "@treeseed/sdk": "0.13.0-rc.65",
     "esbuild": "0.28.2",
     "typescript": "^5.9.3",
     "yaml": "^2.8.1"

--- a/src/provider/coordination/connection-state.ts
+++ b/src/provider/coordination/connection-state.ts
@@ -37,11 +37,23 @@ export async function readProviderConnectionState(dataDir: string, connectionId:
 
 export async function writeProviderConnectionState(dataDir: string, state: ProviderConnectionState) {
 	const path = statePath(dataDir, state.connectionId);
+	const persisted: ProviderConnectionState = {
+		schemaVersion: 1, connectionId: state.connectionId, controlPlaneUrl: state.controlPlaneUrl, offer: state.offer,
+		...(state.serverProfile !== undefined ? { serverProfile: state.serverProfile } : {}),
+		...(state.controlPlaneAudience !== undefined ? { controlPlaneAudience: state.controlPlaneAudience } : {}),
+		...(state.teamId !== undefined ? { teamId: state.teamId } : {}), ...(state.providerId !== undefined ? { providerId: state.providerId } : {}),
+		...(state.registrationRequestId !== undefined ? { registrationRequestId: state.registrationRequestId } : {}),
+		...(state.registrationStatus !== undefined ? { registrationStatus: state.registrationStatus } : {}),
+		...(state.membershipId !== undefined ? { membershipId: state.membershipId } : {}), ...(state.credentialId !== undefined ? { credentialId: state.credentialId } : {}),
+		...(state.credentialRotationIdempotencyKey !== undefined ? { credentialRotationIdempotencyKey: state.credentialRotationIdempotencyKey } : {}),
+		...(state.credentialExchangeIdempotencyKey !== undefined ? { credentialExchangeIdempotencyKey: state.credentialExchangeIdempotencyKey } : {}),
+		...(state.generatedCredentialRef !== undefined ? { generatedCredentialRef: state.generatedCredentialRef } : {}), updatedAt: state.updatedAt,
+	};
 	await mkdir(dirname(path), { recursive: true, mode: 0o700 });
 	const temporary = `${path}.${process.pid}.tmp`;
-	await writeFile(temporary, `${JSON.stringify(state, null, 2)}\n`, { encoding: 'utf8', mode: 0o600, flag: 'wx' });
+	await writeFile(temporary, `${JSON.stringify(persisted, null, 2)}\n`, { encoding: 'utf8', mode: 0o600, flag: 'wx' });
 	await rename(temporary, path);
-	return state;
+	return persisted;
 }
 
 export async function listProviderConnectionStates(dataDir: string) {

--- a/src/provider/coordination/coordinator.ts
+++ b/src/provider/coordination/coordinator.ts
@@ -76,9 +76,9 @@ function nextState(connectionId: string, controlPlaneUrl: string, prior: Provide
 	return next as ProviderConnectionState;
 }
 
-export function providerRegistrationIdempotencyKey(connectionId: string, registrationKey: string) {
-	const enrollmentGeneration = createHash('sha256').update(registrationKey).digest('hex').slice(0, 16);
-	return `register:${connectionId}:${enrollmentGeneration}`;
+export function providerRegistrationIdempotencyKey(connectionId: string, registrationCode: string) {
+	const codeGeneration = createHash('sha256').update(registrationCode).digest('hex').slice(0, 16);
+	return `register:${connectionId}:${codeGeneration}`;
 }
 
 export class CapacityProviderCoordinator {
@@ -166,7 +166,7 @@ export class CapacityProviderCoordinator {
 		return { connectionId: connection.id, status: 'connected', teamId: connection.teamId, providerId: connection.providerId, membershipId: connection.membershipId, runtime: { connection, controlPlaneUrl, controlPlaneAudience, teamId: connection.teamId, providerId: connection.providerId, membershipId: connection.membershipId, credentialId: connection.membershipCredentialId, accessToken } };
 	}
 
-	async beginJoin(join: CapacityProviderJoinInput, oneTimeRegistrationKey?: string): Promise<ProviderConnectionResult> {
+	async beginJoin(join: CapacityProviderJoinInput, suppliedRegistrationCode?: string): Promise<ProviderConnectionResult> {
 		if (this.loaded.manifest.connections.some((connection) => connection.id === join.id)) throw new Error(`Provider connection ${join.id} is already approved and configured.`);
 		const existing = await readProviderConnectionState(this.dataDir, join.id);
 		if (existing?.registrationRequestId) return this.pollRegistrationStatus(join.id);
@@ -177,8 +177,8 @@ export class CapacityProviderCoordinator {
 		const unsigned = unsignedRegistration(this.loaded.manifest, join, identity);
 		const proof = await this.proof({ audience: controlPlaneAudience, method: 'POST', path: providerOperationPath(CONTROL_PLANE_OPERATIONS.providers.register), body: unsigned, identity });
 		const submission: ProviderRegistrationSubmission = { ...unsigned, proof };
-		const registrationKey = oneTimeRegistrationKey ?? await resolveProviderSecret(join.registrationKeyRef, { env: this.options.env, baseDirectory: this.loaded.directory, dataDirectory: this.dataDir, resolver: this.options.secretResolver });
-		const request = await client.register(registrationKey, submission, providerRegistrationIdempotencyKey(join.id, registrationKey));
+		const registrationCode = suppliedRegistrationCode ?? await resolveProviderSecret(join.registrationKeyRef, { env: this.options.env, baseDirectory: this.loaded.directory, dataDirectory: this.dataDir, resolver: this.options.secretResolver });
+		const request = await client.register(registrationCode, submission, providerRegistrationIdempotencyKey(join.id, registrationCode));
 		const state = nextState(join.id, controlPlaneUrl, null, { serverProfile: join.serverProfile ?? null, controlPlaneAudience, offer: join.offer, teamId: request.teamId, providerId: request.providerId, registrationRequestId: request.id, registrationStatus: request.status });
 		await writeProviderConnectionState(this.dataDir, state);
 		return { connectionId: join.id, status: 'pending-approval', teamId: request.teamId, providerId: request.providerId, requestId: request.id };

--- a/src/provider/lifecycle/entrypoint.ts
+++ b/src/provider/lifecycle/entrypoint.ts
@@ -181,15 +181,15 @@ async function main() {
 			emit({ ok: true, connectionId, status: receipt.status, teamId: receipt.teamId, providerId: receipt.providerId, membershipId: receipt.membershipId });
 			return;
 		}
-		const enrollmentToken = String(input.enrollmentToken ?? '');
+		const registrationCode = String(input.registrationCode ?? '');
 		const teamId = String(input.teamId ?? '');
-		if (!enrollmentToken || !teamId) throw new Error('Provider enrollment requires a team and one-time token.');
+		if (!registrationCode || !teamId) throw new Error('Provider enrollment requires a team and registration code.');
 		const receipt = await coordinator.beginJoin({ id: connectionId,
 			...(input.serverProfile ? { serverProfile: String(input.serverProfile) } : { controlPlaneUrl: String(input.controlPlaneUrl ?? '') }),
-			controlPlaneAudience: String(input.controlPlaneAudience ?? input.controlPlaneUrl ?? ''), registrationKeyRef: 'memory://one-time',
+			controlPlaneAudience: String(input.controlPlaneAudience ?? input.controlPlaneUrl ?? ''), registrationKeyRef: 'memory://registration-code',
 			offer: { maxConcurrentRunners: loaded.manifest.capacity.maxConcurrentWorkers,
 				capabilities: [...new Set(loaded.manifest.adapters.flatMap((adapter) => adapter.offers.flatMap(({ offer }) => offer.capabilities.map(({ id }) => id))))],
-				metadata: { manifestGeneration: loaded.manifest.configuration.generation } } }, enrollmentToken);
+				metadata: { manifestGeneration: loaded.manifest.configuration.generation } } }, registrationCode);
 		emit({ ok: true, connectionId, status: receipt.status, teamId: receipt.teamId, providerId: receipt.providerId, requestId: receipt.requestId, sandboxIdentity: { signingKeyId, publicJwk } });
 		return;
 	}

--- a/tests/modern/provider-boundary.test.ts
+++ b/tests/modern/provider-boundary.test.ts
@@ -71,11 +71,11 @@ describe('Agent package ownership boundary', () => {
 		}
 	});
 
-	it('binds registration idempotency to the enrollment generation', () => {
-		expect(providerRegistrationIdempotencyKey('primary', 'token-one'))
-			.toBe(providerRegistrationIdempotencyKey('primary', 'token-one'));
-		expect(providerRegistrationIdempotencyKey('primary', 'token-one'))
-			.not.toBe(providerRegistrationIdempotencyKey('primary', 'token-two'));
+	it('binds registration idempotency to the reusable code generation', () => {
+		expect(providerRegistrationIdempotencyKey('primary', 'code-one'))
+			.toBe(providerRegistrationIdempotencyKey('primary', 'code-one'));
+		expect(providerRegistrationIdempotencyKey('primary', 'code-one'))
+			.not.toBe(providerRegistrationIdempotencyKey('primary', 'code-two'));
 	});
 
 	it('stores mutable connections in local custody without rewriting the canonical manifest', async () => {
@@ -114,9 +114,22 @@ describe('Agent package ownership boundary', () => {
 		} finally { rmSync(root, { recursive: true, force: true }); }
 	});
 
+	it('persists only the connection-state allowlist and drops registration-code values', async () => {
+		const root = mkdtempSync(resolve(tmpdir(), 'treeseed-provider-state-redaction-'));
+		try {
+			await writeProviderConnectionState(root, { schemaVersion: 1, connectionId: 'primary', controlPlaneUrl: 'https://api.example.test',
+				offer: { maxConcurrentRunners: 1, capabilities: ['communication'] }, registrationRequestId: 'request-1', registrationStatus: 'pending',
+				updatedAt: new Date().toISOString(), registrationCode: 'must-not-persist' } as any);
+			const stored = readFileSync(resolve(root, 'connections/primary.json'), 'utf8');
+			expect(stored).not.toContain('registrationCode');
+			expect(stored).not.toContain('must-not-persist');
+		} finally { rmSync(root, { recursive: true, force: true }); }
+	});
+
 	it('contains no raw control-plane paths or removed Market/API runtime terms', () => {
 		const source = sourceFiles(resolve(process.cwd(), 'src')).map((path) => readFileSync(path, 'utf8')).join('\n');
 		expect(source).not.toMatch(/\/v1\//u);
+		expect(source).not.toMatch(/enrollmentToken|one-time token/u);
 		expect(source).not.toMatch(/MarketClient|marketId|marketUrl|marketAudience|TREESEED_MARKET/u);
 		expect(source).not.toMatch(/@treeseed\/sdk\/(?:sdk|platform|operations|copilot|git-runtime|frontmatter|content-operations|agent-tools)(?:['"]|\/)/u);
 	});


### PR DESCRIPTION
## Outcome

Adopts the control-plane API's reusable team registration-code contract for capacity-provider enrollment. The Agent now accepts `registrationCode`, uses it only for the signed initial request, polls an existing durable request without resending it, and explicitly allowlists persisted connection state so registration credentials cannot be serialized.

## Work authority

- Work item / Issue: Closes #71
- Proposal / decision: treeseed-ai/platform#280
- Assignment / checkpoint: treeseed-ai/agent#70 and #71
- Actor: Codex
- Human authority: adrian
- Agent / capacity provider: Codex on the user-authorized development host
- Exact base ref: `staging@4c3ec70645fe41bec70fc84ee87b04b0fe6c2317`
- Exact head ref: `codex/reusable-registration-code-71@f5994a733762dd3967080e789dc97119ca34fc8e`

Contributor mode (select one):

- [ ] Human-authored
- [ ] Agent-assisted under human authority
- [x] Agent-authored under human authority

## Plan

1. Update to the latest exact protected Agent staging head.
2. Adopt SDK `0.13.0-rc.65` and the reusable registration-code vocabulary.
3. Preserve polling and durable lifecycle behavior while preventing credential persistence.
4. Pass focused, full, packed-install, build, and architecture verification.
5. Merge only after Actions pass and after rechecking that protected staging has not moved.
6. Publish and read back the exact accepted Agent RC.

Status: implementation and local verification complete; Actions and protected-branch acceptance pending.

## Changes and commits

- `f5994a733762dd3967080e789dc97119ca34fc8e` — `fix(provider): adopt reusable registration codes`
- Bumps Agent to `0.13.0-rc.37` and SDK to `0.13.0-rc.65`.
- Changes lifecycle input and coordinator terminology from one-time enrollment tokens to reusable team registration codes.
- Retains request-ID-first polling so retries do not resend a registration code after a request exists.
- Persists only an explicit allowlist of connection state fields.
- Adds regression coverage proving a hostile registration-code field/value is absent from the durable state file.

## Verification

Passed on exact head `f5994a733762dd3967080e789dc97119ca34fc8e`:

- `npm ci --ignore-scripts --no-audit --no-fund`
- `npx vitest run --config ./vitest.config.ts tests/modern/provider-boundary.test.ts` — 1 file, 8 tests passed.
- `npm run build:dist`
- `npm run check:file-lengths` — architecture gate passed.
- `npm run verify:direct` — 7 files, 35 tests, build, package creation, and packed-install verification passed.
- `git diff --check origin/staging...HEAD`
- Credential boundary: raw persisted connection state contains neither the `registrationCode` key nor its supplied value.
- Compatibility boundary: registration remains pending/approved/rejected/revoked, and an existing request is polled by request ID without registration-code reuse.

GitHub Actions and release read-back evidence will be recorded by the protected workflows and in issue #71.

## Risk and rollback

Risk is bounded to provider enrollment input vocabulary, idempotency-key derivation, and connection-state serialization. Existing durable request IDs continue to poll without a registration code. Roll back by reverting `f5994a733762dd3967080e789dc97119ca34fc8e` and selecting the last accepted Agent component release; no stored-state migration or destructive action is required.

If `staging` advances before merge, this branch will be rebased onto the new exact protected head and affected verification will be repeated before acceptance.

## Completion summary

The Agent-side reusable registration-code adoption is implemented and locally verified against the latest protected staging head observed immediately before push. Remaining work is Actions acceptance, a final protected-head concurrency check, merge, exact RC publication/read-back, and Platform composition with API `0.8.0-rc.61`. The broader environment-profile and assignment-scoped injection lifecycle remains tracked separately in #70.

## Submission checklist

- [x] The change is bounded to the stated work item and target repository.
- [x] Exact base and head refs are recorded and the branch is ready for review.
- [x] Verification and compatibility evidence are recorded above.
- [x] No plaintext secrets, credentials, machine state, or unrelated residue are included.
- [x] Plan, status, commits, and completion summary form a complete durable record.
- [x] Rollback or recovery steps are documented and executable.
