### PR TITLE
Derive provider team from registration code

### DIFF
--- a/src/provider/lifecycle/enrollment-input.ts
+++ b/src/provider/lifecycle/enrollment-input.ts
@@ -1,0 +1,28 @@
+import type { CapacityProviderJoinInput } from '@treeseed/sdk/capacity-provider';
+
+interface EnrollmentDefaults {
+	maxConcurrentRunners: number;
+	capabilities: string[];
+	manifestGeneration: string;
+}
+
+export function providerEnrollmentInput(input: Record<string, unknown>, defaults: EnrollmentDefaults) {
+	const registrationCode = String(input.registrationCode ?? '');
+	if (!registrationCode) throw new Error('Provider enrollment requires a registration code.');
+	const controlPlaneUrl = String(input.controlPlaneUrl ?? '');
+	const serverProfile = String(input.serverProfile ?? '');
+	if (!controlPlaneUrl && !serverProfile) throw new Error('Provider enrollment requires a control-plane URL or server profile.');
+	const connectionId = String(input.connectionId ?? 'primary');
+	const join: CapacityProviderJoinInput = {
+		id: connectionId,
+		...(serverProfile ? { serverProfile } : { controlPlaneUrl }),
+		controlPlaneAudience: String(input.controlPlaneAudience ?? controlPlaneUrl),
+		registrationKeyRef: 'memory://registration-code',
+		offer: {
+			maxConcurrentRunners: defaults.maxConcurrentRunners,
+			capabilities: [...new Set(defaults.capabilities)],
+			metadata: { manifestGeneration: defaults.manifestGeneration },
+		},
+	};
+	return { connectionId, registrationCode, join };
+}

--- a/src/provider/lifecycle/entrypoint.ts
+++ b/src/provider/lifecycle/entrypoint.ts
@@ -151,7 +151,7 @@ async function main() {
 		const input = await stdinJson();
 		const { createCapacityProviderCoordinator } = await import('../teams/multi-team-runtime.ts');
 		const coordinator = await createCapacityProviderCoordinator(config);
-		const connectionId = String(input.connectionId ?? `local-${String(input.teamId ?? '')}`);
+		const connectionId = String(input.connectionId ?? 'primary');
 		const loaded = await import('../configuration/manifest.ts').then(({ loadProviderManifest }) => loadProviderManifest(config.manifestPath!, config.dataDir));
 		const privateIdentity = await import('../accounts/identity.ts').then(({ ensureCapacityProviderIdentity }) => ensureCapacityProviderIdentity({
 			ref: loaded.manifest.identity.privateKeyRef,
@@ -181,15 +181,13 @@ async function main() {
 			emit({ ok: true, connectionId, status: receipt.status, teamId: receipt.teamId, providerId: receipt.providerId, membershipId: receipt.membershipId });
 			return;
 		}
-		const registrationCode = String(input.registrationCode ?? '');
-		const teamId = String(input.teamId ?? '');
-		if (!registrationCode || !teamId) throw new Error('Provider enrollment requires a team and registration code.');
-		const receipt = await coordinator.beginJoin({ id: connectionId,
-			...(input.serverProfile ? { serverProfile: String(input.serverProfile) } : { controlPlaneUrl: String(input.controlPlaneUrl ?? '') }),
-			controlPlaneAudience: String(input.controlPlaneAudience ?? input.controlPlaneUrl ?? ''), registrationKeyRef: 'memory://registration-code',
-			offer: { maxConcurrentRunners: loaded.manifest.capacity.maxConcurrentWorkers,
-				capabilities: [...new Set(loaded.manifest.adapters.flatMap((adapter) => adapter.offers.flatMap(({ offer }) => offer.capabilities.map(({ id }) => id))))],
-				metadata: { manifestGeneration: loaded.manifest.configuration.generation } } }, registrationCode);
+		const { providerEnrollmentInput } = await import('./enrollment-input.ts');
+		const enrollment = providerEnrollmentInput(input, {
+			maxConcurrentRunners: loaded.manifest.capacity.maxConcurrentWorkers,
+			capabilities: loaded.manifest.adapters.flatMap((adapter) => adapter.offers.flatMap(({ offer }) => offer.capabilities.map(({ id }) => id))),
+			manifestGeneration: loaded.manifest.configuration.generation,
+		});
+		const receipt = await coordinator.beginJoin(enrollment.join, enrollment.registrationCode);
 		emit({ ok: true, connectionId, status: receipt.status, teamId: receipt.teamId, providerId: receipt.providerId, requestId: receipt.requestId, sandboxIdentity: { signingKeyId, publicJwk } });
 		return;
 	}

--- a/tests/modern/provider-boundary.test.ts
+++ b/tests/modern/provider-boundary.test.ts
@@ -10,6 +10,7 @@ import { ensureCapacityProviderIdentity } from '../../src/provider/accounts/iden
 import { listProviderConnectionStates, writeProviderConnectionState } from '../../src/provider/coordination/connection-state.ts';
 import { loadProviderManifest, writeProviderConnections } from '../../src/provider/configuration/manifest.ts';
 import { buildProviderPlan, providerAvailabilityCapabilities } from '../../src/provider/lifecycle/lifecycle.ts';
+import { providerEnrollmentInput } from '../../src/provider/lifecycle/enrollment-input.ts';
 import { stringify as stringifyYaml } from 'yaml';
 import { createManagedProviderManifestV5 } from '../../src/provider/configuration/managed-manifest.ts';
 import { validateCapacityProviderManifestV5 } from '@treeseed/sdk/capacity-provider';
@@ -91,6 +92,18 @@ describe('Agent package ownership boundary', () => {
 			.toBe(providerRegistrationIdempotencyKey('primary', 'code-one'));
 		expect(providerRegistrationIdempotencyKey('primary', 'code-one'))
 			.not.toBe(providerRegistrationIdempotencyKey('primary', 'code-two'));
+	});
+
+	it('lets the registration code resolve team authority without a separate team input', () => {
+		const enrollment = providerEnrollmentInput({ connectionId: 'primary', controlPlaneUrl: 'https://api.example.test',
+			registrationCode: 'team-prefixed-registration-code' }, { maxConcurrentRunners: 2,
+			capabilities: ['communication', 'communication'], manifestGeneration: 'release-1' });
+		expect(enrollment.join).toMatchObject({ id: 'primary', controlPlaneUrl: 'https://api.example.test',
+			controlPlaneAudience: 'https://api.example.test', registrationKeyRef: 'memory://registration-code',
+			offer: { maxConcurrentRunners: 2, capabilities: ['communication'], metadata: { manifestGeneration: 'release-1' } } });
+		expect(enrollment.join).not.toHaveProperty('teamId');
+		expect(() => providerEnrollmentInput({ controlPlaneUrl: 'https://api.example.test' }, { maxConcurrentRunners: 1,
+			capabilities: [], manifestGeneration: 'release-1' })).toThrow(/registration code/u);
 	});
 
 	it('stores mutable connections in local custody without rewriting the canonical manifest', async () => {


### PR DESCRIPTION
## Outcome

Capacity-provider enrollment now lets the registration code resolve the owning team through the control-plane API. The installer/runtime no longer requires or accepts a redundant team identity to begin enrollment.

## Work authority

- Work item / Issue: treeseed-ai/agent#70
- Proposal / decision: treeseed-ai/platform#280 capacity-provider registration-code contract
- Assignment / checkpoint: Production-release implementation requested by Adrian Webb
- Actor: Codex primary agent
- Human authority: Adrian Webb
- Agent / capacity provider: Codex on dev2
- Exact base ref: staging 1b2aec1978824ab32eebe32780fc892d8b071272
- Exact head ref: codex/issue-70-registration-code-team-resolution b2a928f7eedeccb3f5b185f42fabf43a2fb4c758

Contributor mode (select one):

- [ ] Human-authored
- [ ] Agent-assisted under human authority
- [x] Agent-authored under human authority

## Plan

Remove the obsolete team input at the Agent enrollment boundary, preserve one-time registration-code custody, and prove the join submitted to the API contains no team identity.

## Changes and commits

- `b2a928f` derives team authority from the registration response and adds a pure validated enrollment-input boundary.
- Duplicate capabilities are normalized before submission.
- No registration code or team value is persisted in the canonical manifest.

## Verification

- `npm test -- --run tests/modern/provider-boundary.test.ts`: 11 tests passed.
- `npm run lint`: file architecture and distribution build passed.
- The new contract test proves the join contains no `teamId` and still requires a registration code and control-plane target.

## Risk and rollback

Risk is limited to the pre-approval enrollment input boundary. Revert `b2a928f` to restore the prior disabled/redundant team behavior; existing approved provider connections are unchanged.

## Completion summary

The Agent can now submit a registration code alone and accept the authoritative team ID returned by the API. Deployment still needs to perform the protected one-time credential handoff during host initialization.

## Submission checklist

- [x] The change is bounded to the stated work item and target repository.
- [x] Exact base and head refs are recorded and the branch is ready for review.
- [x] Verification and compatibility evidence are recorded above.
- [x] No plaintext secrets, credentials, machine state, or unrelated residue are included.
- [x] Plan, status, commits, and completion summary form a complete durable record.
- [x] Rollback or recovery steps are documented and executable.

