### PR TITLE
Bind Agent release environments to protected branches

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,11 +1,12 @@
 name: Build or Promote TreeSeed Agent Candidate
 on:
   push:
-    branches: [staging]
+    branches: [staging, main]
     tags: ["*.*.*"]
+    paths-ignore: ['.github/workflows/publish.yml']
 jobs:
   candidate-package:
-    if: github.ref == 'refs/heads/staging'
+    if: github.ref == 'refs/heads/staging' || github.ref == 'refs/heads/main'
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262
@@ -18,9 +19,9 @@ jobs:
       - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
         with: { name: "agent-source-${{ github.sha }}", path: source-assets/, if-no-files-found: error }
   candidate-build:
-    if: github.ref == 'refs/heads/staging'
+    if: github.ref == 'refs/heads/staging' || github.ref == 'refs/heads/main'
     needs: [candidate-package, candidate-base-build]
-    environment: staging
+    environment: ${{ github.ref_name == 'main' && 'production' || 'staging' }}
     runs-on: ${{ matrix.runner }}
     strategy:
       matrix:
@@ -57,9 +58,9 @@ jobs:
         if: matrix.target == 'sandbox-codex'
         run: docker run --rm --entrypoint /usr/local/bin/codex "${{ matrix.image }}:candidate-${{ github.sha }}-${{ matrix.arch }}" --version | grep -Fx 'codex-cli 0.149.0'
   candidate-base-build:
-    if: github.ref == 'refs/heads/staging'
+    if: github.ref == 'refs/heads/staging' || github.ref == 'refs/heads/main'
     needs: candidate-package
-    environment: staging
+    environment: ${{ github.ref_name == 'main' && 'production' || 'staging' }}
     runs-on: ${{ matrix.runner }}
     strategy:
       matrix:
@@ -81,9 +82,9 @@ jobs:
       - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
         with: { name: "sandbox-base-digest-${{ github.sha }}-${{ matrix.arch }}", path: digest.txt, if-no-files-found: error }
   candidate-seal:
-    if: github.ref == 'refs/heads/staging'
+    if: github.ref == 'refs/heads/staging' || github.ref == 'refs/heads/main'
     needs: [candidate-build, candidate-base-build]
-    environment: staging
+    environment: ${{ github.ref_name == 'main' && 'production' || 'staging' }}
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262
@@ -117,7 +118,7 @@ jobs:
     if: startsWith(github.ref, 'refs/tags/')
     runs-on: ubuntu-24.04
     permissions: { actions: read, contents: write, id-token: write }
-    environment: production
+    environment: ${{ contains(github.ref_name, '-') && 'staging' || 'production' }}
     steps:
       - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262
         with: { fetch-depth: 0 }
@@ -130,8 +131,9 @@ jobs:
       - name: Download exact accepted candidate
         env: { GH_TOKEN: "${{ secrets.GITHUB_TOKEN }}" }
         run: |
-          test "$(git rev-parse HEAD)" = "$(git rev-parse origin/staging)"
-          run_id="$(gh run list --workflow publish.yml --branch staging --commit "$GITHUB_SHA" --status success --limit 1 --json databaseId --jq '.[0].databaseId')"; test -n "$run_id"
+          if [[ "$GITHUB_REF_NAME" == *-* ]]; then candidate_branch=staging; else candidate_branch=main; fi
+          test "$(git rev-parse HEAD)" = "$(git rev-parse "origin/${candidate_branch}")"
+          run_id="$(gh run list --workflow publish.yml --branch "$candidate_branch" --commit "$GITHUB_SHA" --status success --limit 1 --json databaseId --jq '.[0].databaseId')"; test -n "$run_id"
           gh run download "$run_id" --name "agent-candidate-${GITHUB_SHA}" --dir candidate
           npm run release:check-tag; npm run release:custody -- verify candidate/release-evidence-v1.json
       - id: before

--- a/tests/modern/release-publication.test.ts
+++ b/tests/modern/release-publication.test.ts
@@ -10,13 +10,16 @@ describe('Agent RC publication', () => {
 	it('builds a protected staging candidate and promotes exact custody without rebuilding', () => {
 		const source = readFileSync('.github/workflows/publish.yml', 'utf8');
 		const workflow = parse(source) as { jobs: Record<string, { if?: string; needs?: string | string[]; steps?: Array<{ uses?: string }> }> };
-		expect(workflow.jobs['candidate-build']?.if).toBe("github.ref == 'refs/heads/staging'");
+		expect(workflow.jobs['candidate-build']?.if).toBe("github.ref == 'refs/heads/staging' || github.ref == 'refs/heads/main'");
 		expect(workflow.jobs['candidate-base-build']?.needs).toBe('candidate-package');
 		expect(workflow.jobs['candidate-build']?.needs).toEqual(['candidate-package', 'candidate-base-build']);
 		expect(workflow.jobs['candidate-seal']?.needs).toEqual(['candidate-build', 'candidate-base-build']);
 		expect(workflow.jobs.promote?.if).toBe("startsWith(github.ref, 'refs/tags/')");
 		expect(workflow.jobs.promote?.steps?.some(({ uses }) => uses?.includes('docker/build-push-action'))).toBe(false);
 		expect(source).toContain('release-evidence-v1.json');
+		expect(source).toContain("environment: ${{ contains(github.ref_name, '-') && 'staging' || 'production' }}");
+		expect(source).toContain('candidate_branch=staging; else candidate_branch=main');
+		expect(source).toContain("paths-ignore: ['.github/workflows/publish.yml']");
 	});
 
 	it('materializes an exact no-build production bundle', () => {


### PR DESCRIPTION
## Outcome

Agent RC candidates/tags use staging and stable candidates/tags use production from exact main. No environment reviewer or wait timer is introduced, and workflow-only staging edits do not rebuild the OCI matrix.

## Work authority

- Work item / Issue: Closes https://github.com/treeseed-ai/agent/issues/85
- Proposal / decision: User-directed sole human gate at the production PR into main.
- Assignment / checkpoint: Agent release-boundary audit.
- Actor: OpenAI Codex primary agent
- Human authority: TreeSeed repository owner in the active Codex task
- Agent / capacity provider: OpenAI Codex / dev2
- Exact base ref: staging at 99b6b621cdbaf880d3fa0d8312dea7d62e58e692
- Exact head ref: codex/release-environment-boundary at 153024c605b872a8893cfe3b171bbfd9fa1fbfff

Contributor mode (select one):

- [ ] Human-authored
- [ ] Agent-assisted under human authority
- [x] Agent-authored under human authority

## Plan

Generalize candidate custody to staging/main, select environment and source branch by release channel, add tag ref policies, and skip costly image builds for workflow-only pushes. Complete.

## Changes and commits

- `153024c605b872a8893cfe3b171bbfd9fa1fbfff` changes only the publication workflow and its contract test.

## Verification

- Targeted release-publication contract: 1 file / 4 tests passed.
- GitHub Actions verify passed.

## Risk and rollback

Stable releases now require an exact candidate sealed on main. Revert the commit before the next tag to restore prior behavior. No provider, sandbox, image, or runtime implementation changes.

## Completion summary

Release-channel behavior is corrected; validation reruns after this durable record update, then staging merge is automatic.

## Submission checklist

- [x] The change is bounded to the stated work item and target repository.
- [x] Exact base and head refs are recorded and the branch is ready for review.
- [x] Verification and compatibility evidence are recorded above.
- [x] No plaintext secrets, credentials, machine state, or unrelated residue are included.
- [x] Plan, status, commits, and completion summary form a complete durable record.
- [x] Rollback or recovery steps are documented and executable.
